### PR TITLE
Add Claude/Cursor agent config, and fix the silent bugs it uncovered

### DIFF
--- a/.claude/commands/build-bits-component.md
+++ b/.claude/commands/build-bits-component.md
@@ -1,0 +1,281 @@
+# Build Bits UI Component
+
+Build a production-quality interactive component using Bits UI primitives, Tailwind v4 utility
+classes, and Svelte 5 runes.
+
+Component to build: $ARGUMENTS
+
+---
+
+## The Stack
+
+| Layer            | Tool                       | Rule                                                   |
+| ---------------- | -------------------------- | ------------------------------------------------------ |
+| Behaviour / a11y | Bits UI                    | Never build custom ARIA from scratch                   |
+| Styling          | Tailwind CSS v4            | Mapped design tokens only; no raw hex; never UnoCSS    |
+| State            | Svelte 5 runes             | `$state`, `$derived`, `$bindable`                      |
+| Composition      | Snippets                   | No `<slot>`                                            |
+| Class merging    | `$derived` template string | No `cn()` in this repo; incoming `class` goes **last** |
+
+---
+
+## Step 1 — Choose the Right Bits UI Primitive
+
+| Component need                | Bits UI import               |
+| ----------------------------- | ---------------------------- |
+| Modal / confirmation          | `Dialog`                     |
+| Dropdown actions menu         | `DropdownMenu`               |
+| Contextual floating panel     | `Popover`                    |
+| Hover tooltip                 | `Tooltip`                    |
+| List selection (single/multi) | `Select`                     |
+| Filterable list               | `Combobox`                   |
+| Expand/collapse               | `Accordion` or `Collapsible` |
+| Horizontal sections           | `Tabs`                       |
+| Binary toggle                 | `Switch`                     |
+| Checkbox (tri-state)          | `Checkbox`                   |
+| Group of exclusive options    | `RadioGroup`                 |
+| Searchable command menu       | `Command`                    |
+| Right-click menu              | `ContextMenu`                |
+| Navigation links              | `NavigationMenu`             |
+| Progress indicator            | `Progress`                   |
+| Range selector                | `Slider`                     |
+
+---
+
+## Step 2 — File Location
+
+Flat layout — one file, no folder:
+
+```
+packages/ui/src/components/$ARGUMENTS.svelte
+```
+
+---
+
+## Step 3 — Component Anatomy (Complete Template)
+
+```svelte
+<script lang="ts">
+	// 1. Bits UI import
+	import { Dialog } from 'bits-ui'; // replace with the correct primitive
+	import type { Snippet } from 'svelte';
+
+	// 2. Props — typed inline, always accept class
+	let {
+		open = $bindable(false),
+		// Callback props (replaces createEventDispatcher)
+		onOpenChange,
+		// Content props
+		title,
+		description,
+		// Snippet props (replaces slots)
+		children,
+		trigger,
+		// Class forwarding
+		class: className = '',
+		// Rest props for HTML passthrough
+		...rest
+	}: {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+		title: string;
+		description?: string;
+		children: Snippet;
+		trigger: Snippet;
+		class?: string;
+		[key: string]: unknown;
+	} = $props();
+
+	// 3. Derived classes — className LAST so callers can override
+	const contentClass = $derived(
+		`fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2
+		 bg-background rounded-card border border-border-input p-6 shadow-card
+		 data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out ${className}`
+	);
+</script>
+
+<!-- 4. Markup — semantic, token-only classes -->
+<Dialog.Root bind:open {onOpenChange}>
+	<Dialog.Trigger>
+		{@render trigger()}
+	</Dialog.Trigger>
+
+	<Dialog.Portal>
+		<Dialog.Overlay
+			class="fixed inset-0 z-50 bg-dark/40 backdrop-blur-sm
+			       data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out"
+		/>
+		<Dialog.Content class={contentClass} {...rest}>
+			<Dialog.Title class="text-lg font-semibold text-foreground">{title}</Dialog.Title>
+			{#if description}
+				<Dialog.Description class="mt-1 text-sm text-muted-foreground">
+					{description}
+				</Dialog.Description>
+			{/if}
+			<div class="mt-4">
+				{@render children()}
+			</div>
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+```
+
+---
+
+## Step 4 — Animations
+
+`tailwindcss-animate` is **not installed**. `animate-in`, `animate-out`, `fade-in-0`, and
+`zoom-in-95` do not exist here and silently produce nothing.
+
+Use the named animations declared under `@theme inline` in `packages/ui/src/styles/globals.css`:
+
+| Utility                                                                 | Use for                |
+| ----------------------------------------------------------------------- | ---------------------- |
+| `animate-fade-in` / `animate-fade-out`                                  | overlays, tooltips     |
+| `animate-scale-in` / `animate-scale-out`                                | dialogs, popovers      |
+| `animate-accordion-down` / `animate-accordion-up`                       | Accordion, Collapsible |
+| `animate-enter-from-left` / `-right`, `animate-exit-to-left` / `-right` | tabs, navigation menus |
+| `animate-caret-blink`                                                   | text-input carets      |
+
+```svelte
+<!-- Fade + scale (dialogs, popovers) -->
+class="data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out"
+
+<!-- Height (accordion, collapsible) — keyframes already read --bits-accordion-content-height -->
+class="overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up"
+```
+
+Always define **both** the open and closed variant, or the exit animation never runs.
+
+Need a new one? Add `--animate-<name>` **and** its `@keyframes` inside the same `@theme inline`
+block, then add the class to the `prefers-reduced-motion: reduce` reset block further down the file.
+
+### Transitions with the `child` snippet
+
+```svelte
+<!-- Floating content (Tooltip, Popover, Select, Dropdown) -->
+<Tooltip.Content>
+	{#snippet child({ wrapperProps, props, open })}
+		{#if open}
+			<div {...wrapperProps}>
+				<!-- wrapperProps handles positioning — NEVER style this div -->
+				<div {...props} transition:fade={{ duration: 150 }} class="…tooltip styles…">
+					Tooltip text
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</Tooltip.Content>
+```
+
+> **Critical rule for floating components** (`Tooltip.Content`, `Popover.Content`, `Select.Content`,
+> `DropdownMenu.Content`, `Combobox.Content`):
+>
+> - Always use the two-level structure: outer `{...wrapperProps}` + inner `{...props}`
+> - Never style the `wrapperProps` element — it handles positioning
+> - All styling goes on the inner `props` element
+
+---
+
+## Step 5 — State Management
+
+```svelte
+<!-- Uncontrolled -->
+<Dialog.Root>…</Dialog.Root>
+
+<!-- Controlled -->
+<script lang="ts">
+	let isOpen = $state(false);
+</script>
+<Dialog.Root bind:open={isOpen} onOpenChange={(v) => (isOpen = v)}>…</Dialog.Root>
+
+<!-- Function binding (gated updates) -->
+<script lang="ts">
+	let value = $state('');
+	function getValue() {
+		return value;
+	}
+	function setValue(next: string) {
+		if (!isValid(next)) {
+			return;
+		}
+		value = next;
+	}
+</script>
+<Select.Root bind:value={getValue, setValue}>…</Select.Root>
+```
+
+---
+
+## Step 6 — Design Token Reference
+
+Use only tokens mapped in `@theme inline`. **Verify before use** — this system has no `primary`,
+`secondary`, `ring`, `input`, `card`, or `popover`. Those shadcn-style names emit no CSS at all and
+Tailwind gives no warning.
+
+```
+BACKGROUNDS            FOREGROUNDS               BORDERS
+bg-background          text-foreground           border-border
+bg-background-alt      text-foreground-alt       border-border-input
+bg-muted               text-muted-foreground     border-border-input-hover
+bg-accent              text-accent-foreground    border-border-card
+bg-dark                text-line
+bg-destructive         text-destructive-foreground
+bg-tertiary            text-contrast
+
+RADIUS                 SHADOWS                   OPACITY
+rounded-card           shadow-card               bg-dark/40
+rounded-card-lg        shadow-btn                text-foreground/80
+rounded-card-sm        shadow-popover
+rounded-input          shadow-mini
+rounded-button         shadow-kbd
+
+TYPE                   SPACING
+font-sans (Geist)      spacing-input
+font-mono (Geist Mono) spacing-input-sm
+font-highlight         text-xxs
+font-alt (Clash Grotesk)
+```
+
+Colors swap automatically under `prefers-color-scheme: dark` — do not add `dark:` variants for color.
+
+---
+
+## Step 7 — Accessibility Checklist
+
+- [ ] All interactive elements reachable by keyboard (Tab, Enter, Space, Escape, Arrows)
+- [ ] No ARIA attributes removed from Bits UI — they are required
+- [ ] `Dialog.Title` and `Dialog.Description` present (or `aria-label` / `aria-labelledby`)
+- [ ] `Dialog.Portal` used for overlays (avoids stacking-context and overflow issues)
+- [ ] **No** `focus-visible:ring-*` added — `globals.css` applies a global focus ring to every element
+- [ ] **No** `outline-none` / `ring-0` without an explicit replacement indicator
+- [ ] `disabled` forwarded to Bits UI, not faked with a class
+- [ ] `aria-live` region for dynamic feedback (toasts, validation errors)
+- [ ] Contrast holds in both light and dark themes
+
+---
+
+## Step 8 — Export from the Barrel
+
+```typescript
+// packages/ui/index.ts
+export { default as $ARGUMENTS } from './src/components/$ARGUMENTS.svelte';
+```
+
+---
+
+## After Building
+
+```bash
+pnpm --filter @a11y.cool/ui lint
+pnpm --filter a11y.cool-website check
+```
+
+Check for:
+
+- No TypeScript errors, no `any`
+- `class` prop accepted, defaulted to `''`, and appended **last**
+- `...rest` spread on the root element
+- All Bits UI sub-components present (Root, Trigger, Content at minimum)
+- Enter **and** exit animations defined with `data-[state=*]` using real project `animate-*` classes
+- Every token used is actually mapped in `@theme inline`

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,0 +1,150 @@
+# Debug
+
+Diagnose and fix errors in the a11y.cool monorepo.
+
+Issue or error message: $ARGUMENTS
+
+## Step 1 — Run Diagnostics
+
+```bash
+pnpm lint                                  # ESLint across all workspaces
+pnpm --filter a11y.cool-website check      # svelte-check — the broad signal
+pnpm check-types                           # tsc, apps/blog only
+pnpm --filter @a11y.cool/ui lint
+pnpm --filter @a11y.cool/data lint
+```
+
+## Step 2 — Common Error Patterns & Fixes
+
+### Svelte 5 / TypeScript
+
+| Error                                        | Fix                                                                                                              |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `export let prop`                            | `let { prop } = $props()`                                                                                        |
+| `$: value = expr`                            | `let value = $derived(expr)`                                                                                     |
+| `on:click={...}`                             | `onclick={...}`                                                                                                  |
+| `<slot>`                                     | `{#snippet children()}` + `{@render children?.()}`                                                               |
+| `createEventDispatcher`                      | Remove; use callback props                                                                                       |
+| `<svelte:component>` deprecated              | `{@const Icon = iconComponent}` then `<Icon />`                                                                  |
+| Cannot find module `@a11y.cool/data`         | `pnpm install`; check the `packages/data/src/index.ts` barrel exports it                                         |
+| Cannot find module `@a11y.cool/ui`           | `pnpm install`; check the **package-root** `packages/ui/index.ts` barrel (not `src/index.ts` — it doesn't exist) |
+| Shared type in the wrong package             | Move the interface to `packages/data/src/types/`; import from `@a11y.cool/data`                                  |
+| Type `any` not allowed                       | Replace with an explicit type or `unknown` + type guard                                                          |
+| Missing `./$types`                           | Run `pnpm --filter a11y.cool-website dev` once to generate `.svelte-kit/types/`                                  |
+| `Property X does not exist on type PageData` | Check what `+page.server.ts`'s `load` actually returns                                                           |
+
+```ts
+// ❌ 'children' is not a valid prop
+// Fix: declare it as a Snippet prop
+let { children }: { children?: import('svelte').Snippet } = $props();
+
+// ❌ $state used outside a Svelte file
+// Fix: rename the file to .svelte.ts for reactive module-level state
+
+// ❌ Cannot use bind: on a non-bindable prop
+// Fix: mark the prop with $bindable()
+let { value = $bindable('') }: { value?: string } = $props();
+
+// ❌ Derived value is a function, not a value
+// Fix: `$derived(expr)` — not `$derived(() => expr)`. Use `$derived.by()` for multi-statement.
+```
+
+### Tailwind classes not applied
+
+```
+// ❌ Classes inside @a11y.cool/ui components missing from the build
+// Fix: apps/blog/src/global.css must contain
+//      @source '../node_modules/@a11y.cool/ui';
+
+// ❌ animate-in / animate-out / fade-in-0 / zoom-in-95 do nothing
+// Cause: tailwindcss-animate is NOT installed.
+// Fix: use the project animations — animate-fade-in, animate-scale-in,
+//      animate-accordion-down, animate-enter-from-left, … (defined in
+//      packages/ui/src/styles/globals.css under @theme inline)
+
+// ❌ prose / prose-lg do nothing
+// Cause: @tailwindcss/typography is NOT installed and there is no @plugin directive.
+// Fix: style CMS HTML via element selectors in packages/ui/src/styles/typography.css
+
+// ❌ bg-primary / bg-secondary / ring-ring / border-input produce no color
+// Cause: this design system has no primary/secondary/ring/input tokens — the shadcn names
+//        emit nothing. Tailwind does not warn; the class is simply dropped.
+// Fix: use a mapped token (bg-dark, text-line, bg-muted, bg-accent, border-border-input,
+//      text-destructive-foreground), or add + map a new one in globals.css
+
+// ❌ Class built by string interpolation never appears
+class={`text-${size}`}      // WRONG — Tailwind scans for literal strings
+// Fix: use a Record<Variant, string> map of complete class strings
+```
+
+### Ghost / Directus data
+
+```
+// ❌ Posts list is empty with no error
+// Cause: isGhostConfigured() returned false — VITE_GHOST_API_URL / VITE_GHOST_CONTENT_API_KEY unset.
+// This is by design: the data layer warns and returns [] instead of throwing. Check the server log.
+
+// ❌ getHome()/getAbout() returns null
+// Cause: VITE_API_URL / VITE_API_TOKEN unset, or GraphQL errors (logged as a warning by directusFetch).
+
+// ❌ New Ghost field is always undefined
+// Fix: add it to BOTH the `fields` array in the browse() call AND the mapper AND post.type.ts
+
+// ❌ /blog returns 404 in dev
+// Cause: PUBLIC_BLOG_ENABLED is not 'true'. hooks.server.ts gates the whole /blog subtree.
+```
+
+### Bits UI
+
+```
+// ❌ Floating content (Tooltip, Select, Popover) positioned incorrectly
+// Fix: use the Portal wrapper; with the child snippet use the two-level structure:
+{#snippet child({ wrapperProps, props, open })}
+  {#if open}
+    <div {...wrapperProps}>       ← positioning wrapper, NEVER style this
+      <div {...props}>…</div>     ← your styles go here
+    </div>
+  {/if}
+{/snippet}
+
+// ❌ Component not responding to keyboard
+// Fix: never remove aria-* attributes; never set tabindex="-1" on interactive elements
+
+// ❌ Close animation never runs
+// Fix: define BOTH data-[state=open]:animate-* AND data-[state=closed]:animate-*
+```
+
+### SvelteKit routing
+
+```
+// ❌ Cannot import a server-side module in +page.ts
+// Fix: move it to +page.server.ts. All CMS access is server-only here (clients read process.env).
+
+// ❌ Page renders but has no meta tags
+// Fix: return `pageMetaTags` from load — +layout.svelte deep-merges it with baseMetaTags
+
+// ❌ CSP blocks a script/font/image in production
+// Fix: the CSP is set in apps/blog/src/routes/+layout.server.ts, not netlify.toml
+```
+
+### Build / Turborepo
+
+```bash
+# Clear Turborepo cache and rebuild
+rm -rf .turbo && pnpm build
+
+# Clear all node_modules and reinstall
+find . -name 'node_modules' -type d -prune -exec rm -rf {} + && pnpm install
+
+# Check which workspace is failing
+pnpm --filter <name> build
+```
+
+## Step 3 — Verify Fix
+
+```bash
+pnpm lint
+pnpm --filter a11y.cool-website check
+```
+
+Fix **all** errors before considering the task complete. Zero `any`. Treat a11y warnings as errors.

--- a/.claude/commands/new-component.md
+++ b/.claude/commands/new-component.md
@@ -1,0 +1,158 @@
+# New UI Component
+
+Create a new shared UI component in `packages/ui`.
+
+Component name: $ARGUMENTS
+
+## Steps
+
+1. Create `packages/ui/src/components/$ARGUMENTS.svelte` — Svelte 5 component using `$props()` and runes
+2. Add one export line to the package-root barrel `packages/ui/index.ts`
+3. Verify with `pnpm --filter a11y.cool-website check`
+
+> This repo uses a **flat** component layout — no per-component folder, no per-component `index.ts`,
+> and **no `cn()` helper**. Do not introduce any of those.
+
+---
+
+## Template A — Simple/Display Component
+
+Use for: cards, badges, labels, dividers, skeletons, avatars, stat displays.
+
+```svelte
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		title = '',
+		class: className = '',
+		children = undefined as Snippet | undefined,
+		...props
+	}: {
+		title?: string;
+		class?: string;
+		children?: Snippet;
+		[key: string]: unknown;
+	} = $props();
+
+	const rootClass = $derived(
+		`rounded-card border border-border-input bg-background-alt p-6 ${className}`
+	);
+</script>
+
+<article class={rootClass} {...props}>
+	{#if title}
+		<h3 class="text-xl font-semibold text-foreground">{title}</h3>
+	{/if}
+	{@render children?.()}
+</article>
+```
+
+---
+
+## Template B — Interactive Component (Bits UI)
+
+Use for: dialogs, popovers, dropdowns, selects, tooltips, accordions, tabs.
+
+```svelte
+<script lang="ts">
+	import { Dialog } from 'bits-ui'; // replace with the appropriate primitive
+	import type { Snippet } from 'svelte';
+
+	let {
+		open = $bindable(false),
+		title,
+		description,
+		children,
+		trigger,
+		class: className = ''
+	}: {
+		open?: boolean;
+		title: string;
+		description?: string;
+		children: Snippet;
+		trigger: Snippet;
+		class?: string;
+	} = $props();
+
+	const contentClass = $derived(
+		`fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2
+		 bg-background rounded-card border border-border-input p-6 shadow-card
+		 data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out ${className}`
+	);
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Trigger>
+		{@render trigger()}
+	</Dialog.Trigger>
+	<Dialog.Portal>
+		<Dialog.Overlay
+			class="fixed inset-0 z-50 bg-dark/40 backdrop-blur-sm
+			       data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out"
+		/>
+		<Dialog.Content class={contentClass}>
+			<Dialog.Title class="text-lg font-semibold text-foreground">{title}</Dialog.Title>
+			{#if description}
+				<Dialog.Description class="mt-1 text-sm text-muted-foreground">
+					{description}
+				</Dialog.Description>
+			{/if}
+			<div class="mt-4">
+				{@render children()}
+			</div>
+			<Dialog.Close
+				class="absolute right-4 top-4 rounded-button p-1 text-muted-foreground
+				       hover:bg-muted hover:text-foreground transition-colors"
+			/>
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+```
+
+---
+
+## Add to the Barrel
+
+```ts
+// packages/ui/index.ts — one line, alongside the existing exports
+export { default as $ARGUMENTS } from './src/components/$ARGUMENTS.svelte';
+```
+
+That is the whole public API step. The barrel lives at the **package root**, not in `src/`.
+
+**Shared prop interfaces** (item lists, nav link shapes, CMS document shapes used by more than one
+module) belong in `packages/data/src/types/*.type.ts`, exported from `@a11y.cool/data`. The component
+imports them; `@a11y.cool/ui` must not define them.
+
+Consumers infer prop types via Svelte's helper:
+
+```ts
+import type { ComponentProps } from 'svelte';
+import { $ARGUMENTS } from '@a11y.cool/ui';
+type $ARGUMENTSProps = ComponentProps<typeof $ARGUMENTS>;
+```
+
+---
+
+## Rules
+
+- Use Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`) — never `export let` or `on:` directives
+- Accept a `class` prop defaulting to `''`, and append it **last** in a `$derived` template string so
+  callers can override
+- Spread `...props` on the root element for HTML attribute passthrough
+- Use design tokens only (`bg-background`, `text-foreground`, `border-border-input`, `rounded-card`,
+  `shadow-card`) — never raw hex, never Tailwind's default palette, **never UnoCSS**
+- Before using a token, confirm it is mapped in `@theme inline` in `packages/ui/src/styles/globals.css`.
+  There is no `primary`, `secondary`, `ring`, `input`, `card`, or `popover` in this system — those
+  shadcn-style names emit nothing. Use `dark`/`line`, `muted`, `accent`, `border-input`, `destructive`
+- Use Bits UI primitives for interactive components — never hand-roll ARIA
+- Use snippets (`{@render children?.()}`) — never `<slot>`
+- Do **not** add `focus-visible:ring-*` — `globals.css` applies a global focus ring to every element.
+  Never write `outline-none` without a replacement indicator
+- Animations: use `animate-fade-in` / `animate-scale-in` / `animate-accordion-down` etc. There is no
+  `animate-in`, `fade-in-0`, or `zoom-in-95` — `tailwindcss-animate` is not installed
+- For floating content (Popover, Tooltip, Select, Dropdown): use the two-level `child` snippet
+  structure with `wrapperProps` + `props`
+- Keep variant/size maps as `Record<Variant, string>` with complete literal class strings
+- After creating, run: `pnpm --filter a11y.cool-website check && pnpm --filter @a11y.cool/ui lint`

--- a/.claude/commands/new-data-type.md
+++ b/.claude/commands/new-data-type.md
@@ -1,0 +1,171 @@
+# New Content Type
+
+Add a complete new content type end-to-end, backed by Ghost or Directus.
+
+Content type name: $ARGUMENTS
+
+There is **no CMS app in this repo** — content lives in hosted Ghost (blog posts) and Directus (home,
+about, static pages). Schema changes happen in those services' own admin UIs. This command covers
+everything on the code side.
+
+## Step 0 — Pick the source
+
+| Use Ghost when                                                  | Use Directus when                                                         |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| It's editorial content with authors, tags, and rich HTML bodies | It's structured page/section content the site renders into a fixed layout |
+| Client: `packages/data/src/ghost/ghost.api.ts`                  | Client: `packages/data/src/directus/directus.api.ts`                      |
+
+---
+
+## Step 1 — TypeScript Interface in `packages/data`
+
+Create `packages/data/src/types/$ARGUMENTS.type.ts`:
+
+```typescript
+import type { MetaTagsProps } from 'svelte-meta-tags';
+
+export interface $ARGUMENTS {
+	id: string;
+	title: string;
+	// Optional unless the CMS actually guarantees the field
+	description?: string;
+	content?: string;
+	meta?: MetaTagsProps;
+}
+```
+
+Rules:
+
+- Mark a field optional (`?`) unless the CMS validates its presence — both clients degrade to
+  partial data rather than throwing
+- Ghost-backed types use the **mapped** field names (`_id`, `content`, `coverImage`, `publishedAt`),
+  not Ghost's raw names — see `post.type.ts`
+- Directus-backed types mirror the GraphQL field names directly — see `home.type.ts`
+- Never declare this interface in `apps/blog`, `packages/ui`, or `packages/utils`
+
+---
+
+## Step 2a — Directus: query + getter
+
+Add to `packages/data/src/directus/directus.api.ts`:
+
+```typescript
+export const dataQuery$ARGUMENTS: string = `query {
+    $ARGUMENTS {
+        id
+        title
+        description
+        image { id description }
+    }
+}`;
+
+export const get$ARGUMENTS = async (): Promise<$ARGUMENTS | null> => {
+	const data = (await directusFetch(dataQuery$ARGUMENTS)) as { $ARGUMENTS: $ARGUMENTS } | null;
+	return data?.$ARGUMENTS ?? null;
+};
+```
+
+- Use `directusFetch` — it already guards on missing env vars, surfaces GraphQL `errors`, and returns
+  `null` on failure. Do not add your own try/catch around it.
+- Do **not** extend the legacy `request()` / `getData()` pair in the same file; they read unprefixed
+  env vars and throw.
+- Request only the fields the UI renders.
+- Parameterised queries take an argument: `dataQuery$ARGUMENTS(slug: string)`.
+- Images are UUID references — build URLs with `mediaUrl(uuid)`.
+
+## Step 2b — Ghost: fetch + mapper
+
+Add to `packages/data/src/ghost/ghost.api.ts`:
+
+```typescript
+export const get$ARGUMENTSs = async (): Promise<$ARGUMENTS[]> => {
+	const api = getContentApi();
+	if (!api) {
+		console.warn('Ghost API is not configured; returning no $ARGUMENTS.');
+		return [];
+	}
+
+	try {
+		const items = await api.pages.browse({
+			limit: 'all',
+			fields: ['id', 'title', 'slug', 'html'],
+			formats: ['html']
+		});
+
+		if (!Array.isArray(items)) {
+			return [];
+		}
+
+		return items
+			.filter((i): i is NonNullable<typeof i> => Boolean(i?.id && i?.title))
+			.map((i) => ({ id: i.id!, title: i.title!, content: i.html ?? undefined }));
+	} catch (err) {
+		console.warn('Failed to fetch $ARGUMENTS from Ghost API:', err);
+		return [];
+	}
+};
+```
+
+- Guard with `isGhostConfigured()` / `getContentApi()` — never read env vars at the call site
+- Always list explicit `fields`; filter incomplete records before mapping
+- Map into the project's own shape — never leak Ghost's raw field names to consumers
+
+**The degradation contract is mandatory:** log a warning and return `[]` / `null`. Never throw from
+the data layer. The route decides whether missing data is a 404 or an empty state.
+
+---
+
+## Step 3 — Barrel Export
+
+Add to `packages/data/src/index.ts`:
+
+```typescript
+export * from './types/$ARGUMENTS.type';
+```
+
+The getter is already exported because the barrel re-exports the whole client module.
+
+---
+
+## Step 4 — Consume in `apps/blog`
+
+```typescript
+// apps/blog/src/routes/…/+page.server.ts
+import type { PageServerLoad } from './$types';
+import type { MetaTagsProps } from 'svelte-meta-tags';
+import { get$ARGUMENTS } from '@a11y.cool/data';
+import { error } from '@sveltejs/kit';
+
+export const load = (async () => {
+	const item = await get$ARGUMENTS();
+
+	if (!item) {
+		error(404, 'Not found');
+	}
+
+	const pageMetaTags = {
+		title: item.title,
+		description: item.description
+	} satisfies MetaTagsProps;
+
+	return { item, pageMetaTags };
+}) satisfies PageServerLoad;
+```
+
+Render with components from `@a11y.cool/ui`. Any HTML body must go through `processHtml()` from
+`@a11y.cool/utils` and be rendered by `HtmlRender` — never `{@html}`.
+
+If the content is site-wide (needed on every page), load it in `+layout.server.ts` instead and read
+it from `page.data`.
+
+---
+
+## Step 5 — Verify
+
+```bash
+pnpm --filter a11y.cool-website check
+pnpm lint
+```
+
+Also confirm the page still renders with the CMS env vars **unset** — that is the whole point of the
+degradation contract.

--- a/.claude/commands/new-package.md
+++ b/.claude/commands/new-package.md
@@ -1,0 +1,140 @@
+# New Monorepo Package
+
+Scaffold a new shared package in `packages/`.
+
+Package name: $ARGUMENTS
+
+> **Check first — most new code does not need a new package:**
+>
+> | You want to add            | Put it in                             |
+> | -------------------------- | ------------------------------------- |
+> | A shared type or interface | `packages/data/src/types/*.type.ts`   |
+> | A CMS query or fetcher     | `packages/data/src/{ghost,directus}/` |
+> | A Svelte component         | `packages/ui/src/components/`         |
+> | A pure helper function     | `packages/utils/src/`                 |
+>
+> Only create a package for a genuinely new concern with its own dependency set.
+
+## Steps
+
+### 1. Create the directory structure
+
+Follow the existing convention — the barrel lives at the **package root**, not in `src/`:
+
+```
+packages/$ARGUMENTS/
+├── src/
+│   └── <module>.ts
+├── index.ts
+├── package.json
+└── tsconfig.json
+```
+
+### 2. `package.json`
+
+```json
+{
+	"name": "@a11y.cool/$ARGUMENTS",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"main": "./index.ts",
+	"types": "./index.ts",
+	"exports": {
+		".": {
+			"types": "./index.ts",
+			"import": "./index.ts"
+		}
+	},
+	"license": "MIT",
+	"scripts": {
+		"lint": "eslint . --max-warnings 0"
+	},
+	"devDependencies": {
+		"@a11y.cool/eslint-config": "workspace:*",
+		"@a11y.cool/typescript-config": "workspace:*",
+		"eslint": "^10.5.0",
+		"typescript": "^6.0.3"
+	}
+}
+```
+
+Notes:
+
+- Packages here are **source-only** — consumers import `.ts` directly and Vite compiles it. There is
+  no build step and no `dist/`. Do not add `@sveltejs/package` unless you deliberately change that.
+- There is **no pnpm `catalog:`** in this workspace — pin real semver ranges, matching the versions
+  already used elsewhere in the repo.
+- Add a `check-types` script (`"check-types": "tsc --noEmit"`) if the package can stand alone —
+  currently only `apps/blog` has one, which is a known gap.
+
+> If the package exports Svelte components, also add `"svelte": "^5.56.4"` to `devDependencies`, an
+> `eslint.config.js`, and a `svelte.d.ts` — mirror `packages/ui`.
+
+### 3. `tsconfig.json`
+
+```json
+{
+	"extends": "@a11y.cool/typescript-config/svelte.json"
+}
+```
+
+`svelte.json` is the only shared config in `packages/typescript-config` — there is no `base.json`.
+
+### 4. `index.ts` barrel
+
+```typescript
+export * from './src/<module>.ts';
+```
+
+Explicit `.ts` extensions are used in the existing barrels (`packages/utils/index.ts`) — match that.
+
+### 5. `eslint.config.js`
+
+```javascript
+import { config } from '@a11y.cool/eslint-config';
+
+export default config;
+```
+
+### 6. Register in the workspace
+
+`pnpm-workspace.yaml` already globs `packages/*`, so the package is picked up automatically. To
+consume it:
+
+```json
+{
+	"dependencies": {
+		"@a11y.cool/$ARGUMENTS": "workspace:*"
+	}
+}
+```
+
+Then:
+
+```bash
+pnpm install
+```
+
+### 7. Tailwind source scanning
+
+If the package emits class names used by the app, add it to `apps/blog/src/global.css`:
+
+```css
+@source '../node_modules/@a11y.cool/$ARGUMENTS';
+```
+
+Without this, its classes will be missing from the production CSS.
+
+### 8. turbo.json
+
+Standard `build`, `lint`, `check-types`, and `test` tasks are inherited from the root `turbo.json`.
+Only add overrides if the package needs different outputs.
+
+## After Creating
+
+```bash
+pnpm install
+pnpm --filter @a11y.cool/$ARGUMENTS lint
+pnpm --filter a11y.cool-website check
+```

--- a/.claude/commands/new-route.md
+++ b/.claude/commands/new-route.md
@@ -1,0 +1,158 @@
+# New SvelteKit Route
+
+Create a new page route in `apps/blog/src/routes/`.
+
+Route path: $ARGUMENTS
+
+## Files to Create
+
+---
+
+### `+page.server.ts` — server-side load & actions
+
+All CMS access lives here. The Ghost and Directus clients read `process.env`, so they must never run
+in a universal load.
+
+```typescript
+import type { PageServerLoad, Actions } from './$types';
+import type { MetaTagsProps } from 'svelte-meta-tags';
+import { getPage } from '@a11y.cool/data';
+import { fail, error } from '@sveltejs/kit';
+
+export const load = (async ({ params }) => {
+	const page = await getPage('$ARGUMENTS');
+
+	if (!page) {
+		error(404, 'Not found');
+	}
+
+	const pageMetaTags = {
+		title: page.title,
+		description: 'Page description'
+	} satisfies MetaTagsProps;
+
+	return { page, pageMetaTags };
+}) satisfies PageServerLoad;
+
+// Only add if the page has form actions
+export const actions: Actions = {
+	default: async ({ request }) => {
+		const form = await request.formData();
+		const value = form.get('field') as string;
+		if (!value) {
+			return fail(400, { field: value, missing: true });
+		}
+		return { success: true };
+	}
+};
+```
+
+### `+page.svelte` — page component
+
+```svelte
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { animate, getAnimateInitialClass, processHtml } from '@a11y.cool/utils';
+	import { HtmlRender } from '@a11y.cool/ui';
+
+	let { data }: { data: PageData } = $props();
+
+	const animateInitial = getAnimateInitialClass();
+	let content = $derived(processHtml(data.page?.content));
+</script>
+
+<section
+	class="col-span-12 col-start-1 flex justify-center {animateInitial}"
+	use:animate={{ delay: 100, triggerOnMount: true }}
+>
+	<article class="pt-10 max-w-[580px] w-full">
+		<h1 class="text-4xl font-bold mb-4">{data.page.title}</h1>
+		{#if content}
+			<HtmlRender node={content} />
+		{/if}
+	</article>
+</section>
+```
+
+Notes:
+
+- Do **not** add `<svelte:head><title>` — SEO is handled by `svelte-meta-tags`. Return
+  `pageMetaTags` from `load` and `+layout.svelte` merges it with `baseMetaTags`.
+- The root layout renders a 12-column grid; page sections opt in with
+  `col-span-12 col-start-1`.
+- Never `{@html}` CMS content — run it through `processHtml()` and render with `HtmlRender`.
+
+### `+layout.svelte` — only if this route segment needs its own layout
+
+```svelte
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	let { children }: { children: Snippet } = $props();
+</script>
+
+{@render children?.()}
+```
+
+### `+error.svelte` — only if custom error handling is needed
+
+```svelte
+<script lang="ts">
+	import { page } from '$app/state';
+</script>
+
+<section class="col-span-12 col-start-1">
+	<h1>{page.status}</h1>
+	<p>{page.error?.message}</p>
+</section>
+```
+
+> Use `$app/state`'s `page` (a rune-based object), not the deprecated `$app/stores` `$page`.
+
+---
+
+## Gated Routes
+
+If the new section should be feature-flagged like `/blog`:
+
+1. Add the flag reader to `apps/blog/src/lib/features.ts`
+2. Gate the subtree in `apps/blog/src/hooks.server.ts` with `error(404, 'Not found')`
+3. Add/remove the nav entry in `getNavItems()`
+
+All three must stay in sync — a nav link to a 404 is worse than no link.
+
+---
+
+## Streaming Deferred Data
+
+```typescript
+export const load: PageServerLoad = async () => {
+	return {
+		critical: await loadCriticalData(),
+		deferred: loadSlowData() // not awaited — streams to the client
+	};
+};
+```
+
+```svelte
+{#await data.deferred}
+	<Loader />
+{:then result}
+	<Result {result} />
+{:catch err}
+	<p role="alert">Error: {err.message}</p>
+{/await}
+```
+
+---
+
+## Rules
+
+- Always use `./$types` for `PageLoad`, `PageServerLoad`, `Actions` — never type manually
+- Keep tokens and CMS calls in `+page.server.ts`, never `+page.ts`
+- Import shared types and CMS getters from `@a11y.cool/data`; UI from `@a11y.cool/ui`; helpers from
+  `@a11y.cool/utils`; app-local helpers from `$lib/`
+- Use Svelte 5 runes — `$props()`, never `export let data`
+- `$derived(expr)`, not `$derived(() => expr)`
+- One `<h1>` per page; use semantic landmarks. See `.cursor/accessibility.mdc`
+- Adding a new sitemap entry? Update `apps/blog/src/routes/sitemap.xml/+server.ts`
+- After creating, run: `pnpm --filter a11y.cool-website check && pnpm lint`

--- a/.claude/commands/typecheck.md
+++ b/.claude/commands/typecheck.md
@@ -1,0 +1,50 @@
+# Type Check
+
+Run TypeScript type checking across the monorepo (or a specific package).
+
+Target: $ARGUMENTS
+
+## Instructions
+
+If `$ARGUMENTS` is empty, run the full check:
+
+```bash
+pnpm lint
+pnpm --filter a11y.cool-website check     # svelte-check — covers .svelte + imported packages
+pnpm check-types                           # tsc --noEmit, apps/blog only
+```
+
+> **Important:** only `apps/blog` defines a `check-types` script, so `pnpm check-types` does **not**
+> type-check `packages/*`. `svelte-check` is the broader signal because it follows imports into
+> `@a11y.cool/ui`, `@a11y.cool/data`, and `@a11y.cool/utils`. Never report "types are clean" on the
+> basis of `pnpm check-types` alone.
+
+If `$ARGUMENTS` names a workspace, run its tasks. Package names are:
+
+| Directory        | Workspace name      |
+| ---------------- | ------------------- |
+| `apps/blog`      | `a11y.cool-website` |
+| `packages/ui`    | `@a11y.cool/ui`     |
+| `packages/data`  | `@a11y.cool/data`   |
+| `packages/utils` | `@a11y.cool/utils`  |
+
+```bash
+pnpm --filter <name> lint
+pnpm --filter a11y.cool-website check     # for anything that affects rendered components
+```
+
+## After Running
+
+- Fix ALL TypeScript errors before considering any task complete.
+- Treat Svelte a11y compiler warnings as errors — see `.cursor/accessibility.mdc`.
+- Never use `any` (including `as any`) when fixing type errors. Use `unknown` + a narrowing guard.
+- Common issues:
+    - `export let` → change to `let { prop } = $props()`
+    - `$:` → change to `$derived` / `$derived.by`
+    - `<slot>` → change to `{#snippet}` + `{@render}`
+    - `<svelte:component this={X} />` → assign to a capitalised local, then `<Icon />`
+    - Missing type from `@a11y.cool/data` → add `packages/data/src/types/<name>.type.ts` and export it
+      from `packages/data/src/index.ts`
+    - Shared type defined in `apps/blog`, `packages/ui`, or `packages/utils` → move it to
+      `packages/data/src/types/` per `.cursor/monorepo.mdc`
+    - Missing `./$types` → run `pnpm --filter a11y.cool-website dev` once to generate `.svelte-kit/`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+	"permissions": {
+		"allow": [
+			"Bash(pnpm*)",
+			"Bash(turbo*)",
+			"Bash(node*)",
+			"Bash(ncu*)",
+			"Bash(npx svelte-check*)",
+			"Bash(npm view*)",
+			"Bash(git*)",
+			"Bash(gh*)"
+		],
+		"deny": ["Bash(rm -rf /*)", "Bash(curl* | bash*)", "Bash(wget* | bash*)"]
+	},
+	"hooks": {
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash -c 'echo \"[a11y.cool] Session complete. Verify with: pnpm --filter a11y.cool-website check && pnpm lint\" >&2'"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: update-deps
+description: Use when updating this monorepo's dependencies end-to-end — run update-deps.sh, bump to the newest STABLE majors (no alpha/beta), verify with checks, hold back any major that breaks the toolchain, then commit and ship to dev + main.
+---
+
+# Update Dependencies
+
+Runs the full dependency-update-and-ship workflow for the a11y.cool monorepo: update → install →
+verify → auto-hold breaking majors → commit → push `dev` → fast-forward `main`.
+
+Follow the steps in order. Create a todo per numbered step. Do NOT skip the verification step, and do
+NOT push if checks are red (after the hold-back loop).
+
+## 1. Preflight
+
+```bash
+git fetch origin
+git checkout dev
+git status -sb          # abort if the working tree is dirty
+git log --oneline origin/dev..dev dev..origin/dev   # abort if dev has diverged from origin/dev
+```
+
+- If the tree is dirty or `dev` has diverged, STOP and report — do not proceed.
+- If you are in a Conductor workspace on a feature branch, work on that branch instead and skip the
+  `main` fast-forward in step 6; report that the branch still needs merging.
+
+## 2. Update dependencies
+
+```bash
+./update-deps.sh latest
+```
+
+- `ncu --target latest` already takes the newest **stable** version of each dep and **excludes**
+  alpha/beta/rc prereleases. That is the "new major, no alpha/beta" behavior — do not switch to
+  `--target greatest` (which includes prereleases).
+- Then bump the pnpm pin to the latest **stable** pnpm major:
+    ```bash
+    npm view pnpm dist-tags --json     # use the "latest" tag (never a "next-*"/"*-alpha"/"*-beta" tag)
+    ```
+    Edit `"packageManager": "pnpm@<latest-stable>"` in the root `package.json`. If the newest major is
+    only published as alpha/beta (no stable release), stay on the current major's latest stable and
+    note it.
+
+## 3. Install
+
+```bash
+pnpm install
+```
+
+- `pnpm-workspace.yaml` may gain auto-entries under `minimumReleaseAgeExclude` (pnpm's release-age
+  gate registering the new versions). This is expected — keep it.
+
+## 4. Verify everything
+
+```bash
+pnpm lint
+pnpm --filter a11y.cool-website check     # svelte-check — the broad signal
+pnpm check-types                           # tsc, apps/blog only
+```
+
+- All three must pass before committing. (Build is intentionally omitted for speed — run
+  `pnpm build` too only if asked, or if an adapter/Vite/Tailwind major changed.)
+- Note that `pnpm check-types` only covers `apps/blog`; no `packages/*` defines a `check-types`
+  script. `svelte-check` is what actually exercises the shared UI and data packages.
+
+## 5. Hold back breaking majors (judgment loop)
+
+If a check fails, decide: is this a **real regression from a major bump**, or a **pre-existing error**
+unrelated to this update?
+
+- **Pre-existing** (fails the same way on `origin/dev` before the update): not your problem — note it
+  and continue.
+- **Caused by a stable major** (e.g. TypeScript 7 crashing `svelte-check` with
+  `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`): pin **only that
+  dependency** back to its previous major across every package.json that declares it (root,
+  `apps/blog`, `packages/*`), preserving each file's existing range style (`^x.y.z` vs pinned), then:
+    ```bash
+    pnpm install
+    pnpm lint && pnpm --filter a11y.cool-website check
+    ```
+    Repeat until green. Collect a **held-back list** (dep → version kept, and why).
+
+Known held-back dep: **TypeScript** — pinned to `6.0.3` (exact, not `^`) in the root and
+`apps/blog`; keep at latest `6.x` until `svelte-check` supports TS 7.
+
+Watch list for this repo — these have cross-cutting majors, check release notes before accepting:
+
+| Dep                                                          | Why it's risky                                                                                       |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `tailwindcss` / `@tailwindcss/vite` / `@tailwindcss/postcss` | must move together; v4 config is CSS-first (`@theme inline` in `packages/ui/src/styles/globals.css`) |
+| `svelte` / `svelte-check` / `@sveltejs/vite-plugin-svelte`   | rune and compiler-warning changes                                                                    |
+| `@sveltejs/kit` / `@sveltejs/adapter-netlify`                | adapter must match the Kit major                                                                     |
+| `bits-ui`                                                    | data-attribute and snippet API changes ripple through `packages/ui`                                  |
+| `eslint` / `typescript-eslint` / `eslint-plugin-svelte`      | flat-config shape changes in `packages/eslint-config/index.js`                                       |
+| `vite`                                                       | plugin-API breaks for `@tailwindcss/vite` and `vite-plugin-devtools-json`                            |
+
+## 6. Commit and ship
+
+Only when checks are green:
+
+```bash
+git add -A
+git commit -m "chore: update dependencies and bump pnpm to <version>"   # body: list notable updates + held-back deps
+git push origin dev
+```
+
+Then fast-forward `main` from `dev`. `main` is checked out in a **separate worktree**
+(`/Users/simon/Development/accessibility.cool/blog`), so `git checkout main` fails here — push the
+ref directly instead:
+
+```bash
+git merge-base --is-ancestor origin/main dev && echo "ff-safe"   # must print ff-safe
+git push origin dev:main
+```
+
+Then update the local `main` worktree so it isn't left behind:
+
+```bash
+git -C /Users/simon/Development/accessibility.cool/blog fetch origin
+git -C /Users/simon/Development/accessibility.cool/blog merge --ff-only origin/main
+```
+
+- If `git merge-base --is-ancestor` does NOT report ff-safe, `main` has commits `dev` lacks — STOP
+  and report instead of force-pushing.
+
+## 7. Report
+
+Summarize:
+
+- What updated (highlight majors).
+- What was **held back** and why.
+- Final branch state — `origin/dev`, `origin/main`, and local `main` should all point at the new commit.

--- a/.cursor/accessibility.mdc
+++ b/.cursor/accessibility.mdc
@@ -1,0 +1,142 @@
+---
+description: Accessibility rules — a11y is the product on this project, not a checklist item
+globs:
+    - 'apps/blog/**/*.{svelte,ts}'
+    - 'packages/ui/**/*.{svelte,ts,css}'
+alwaysApply: true
+docs:
+    - name: WCAG 2.2 Quick Reference
+      url: https://www.w3.org/WAI/WCAG22/quickref/
+    - name: ARIA Authoring Practices Guide
+      url: https://www.w3.org/WAI/ARIA/apg/
+    - name: Svelte a11y warnings
+      url: https://svelte.dev/docs/svelte/compiler-warnings
+---
+
+# Accessibility
+
+This site is **about** accessibility. A shipped a11y regression is an on-brand failure, not a minor
+bug. Treat Svelte's compiler a11y warnings as errors — never silence one with
+`<!-- svelte-ignore a11y_… -->` without a written justification in the same commit.
+
+## Focus is Handled Globally — Do Not Re-implement It
+
+`packages/ui/src/styles/globals.css` applies a focus ring to **every** element:
+
+```css
+*:not(body):not(.focus-override) {
+	&:focus-visible {
+		@apply focus-visible:ring-foreground focus-visible:ring-offset-background
+		       focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-1 rounded-xs;
+	}
+}
+```
+
+Consequences:
+
+- **Do not** add per-component `focus-visible:ring-*` classes — they are redundant
+- **Never** write `outline-none` / `focus:outline-none` / `ring-0` to "clean up" a design. Removing
+  the indicator without an equal-or-better replacement is a WCAG 2.4.7 failure
+- If a component genuinely needs a custom indicator, add `focus-override` to opt out of the global
+  rule **and** define the replacement in the same change
+
+## Motion
+
+`prefers-reduced-motion: reduce` is honoured in three places — keep all three working:
+
+1. `globals.css` neutralises every `animate-*` and `animate-initial-*` class
+2. The `animate` action in `@a11y.cool/utils` returns a no-op before observing anything
+3. `Eyes.svelte` checks `matchMedia('(prefers-reduced-motion: reduce)')` for its JS-driven motion
+
+Any new JS-driven motion must add its own `matchMedia` guard — CSS-only rules cannot stop it.
+
+```svelte
+<script lang="ts">
+	import { animate, getAnimateInitialClass } from '@a11y.cool/utils';
+	const initial = getAnimateInitialClass('fly-in-up');
+</script>
+
+<section use:animate={{ delay: 100 }} class={initial}>…</section>
+```
+
+`getAnimateInitialClass()` must be on the same node as `use:animate` — it supplies the hidden state in
+the SSR HTML. Without it the element flashes visible before hydration; with it but **without** the
+action, the element stays permanently invisible for users with JS disabled.
+
+## Semantics First
+
+- Use real elements: `nav`, `main`, `article`, `header`, `footer`, `button`, `a`, `label`
+- A `<button>` that navigates should be an `<a>`; an `<a>` that acts should be a `<button>`
+- One `<h1>` per page. Never skip heading levels to get a font size — sizes come from
+  `typography.css`, which styles `h1`–`h5` by element
+- Reach for Bits UI before writing ARIA by hand — see
+  [bitsui-components.mdc](mdc:.cursor/bitsui-components.mdc)
+- Interactive non-button elements need `role`, `tabindex="0"`, and Enter/Space key handling. This is
+  almost always a sign you should have used a `<button>`
+
+## Typography
+
+`@tailwindcss/typography` is **not installed** and there is no `@plugin` directive, so `prose` /
+`prose-lg` generate no CSS. Do not reach for them.
+
+CMS HTML is styled by the bare-element rules in `packages/ui/src/styles/typography.css` (`h1`–`h5`,
+`p`, and helper classes), which apply globally. To restyle rendered content, edit that file rather
+than adding `prose-*` modifiers.
+
+## Images and Media
+
+- Every `<img>` needs an `alt`. Decorative images get `alt=""`, never a missing attribute
+- Do not use the post title as the cover-image `alt` when the title is already an adjacent `<h1>` —
+  that double-announces. Prefer `alt=""` for a purely decorative cover
+- Directus images come from `mediaUrl(uuid)`; the collection carries a `description` field — use it
+  as the `alt` text
+
+## Forms
+
+- Every input has an associated `<label for="id">` (preferred) or an `aria-label`
+- Never rely on placeholder text as the label
+- Associate errors with `aria-describedby` and announce them in an `aria-live="polite"` region
+- Group related controls in a `<fieldset>` with a `<legend>`
+
+## Color and Contrast
+
+- Use design tokens only — they are the pairs that have been contrast-checked
+  (`bg-background`/`text-foreground`, `bg-muted`/`text-muted-foreground`)
+- Verify any **new** token pair meets WCAG AA (4.5:1 body, 3:1 large text and UI boundaries) in
+  **both** light and dark, since tokens swap under `prefers-color-scheme`
+- Never encode meaning in color alone — pair it with text, an icon, or a pattern
+
+## Dynamic Content
+
+- Announce async results in an `aria-live="polite"` region (`assertive` only for genuine errors)
+- After client-side navigation, move focus to the page heading:
+
+```ts
+import { afterNavigate } from '$app/navigation';
+
+afterNavigate(() => {
+	const heading = document.querySelector('h1');
+	if (heading) {
+		heading.setAttribute('tabindex', '-1');
+		heading.focus();
+	}
+});
+```
+
+## Verification
+
+```bash
+pnpm --filter a11y.cool-website check   # svelte-check surfaces a11y compiler warnings
+pnpm lint                               # eslint-plugin-svelte a11y rules
+```
+
+Manual checks before calling UI work done:
+
+- [ ] Tab through the whole flow — every interactive element is reachable and visibly focused
+- [ ] Escape closes overlays; Arrow keys move within menus/tabs
+- [ ] Zoom to 200% — no clipped or overlapping content
+- [ ] Toggle OS dark mode — contrast holds in both themes
+- [ ] Enable "Reduce motion" — no animation runs, nothing stays invisible
+
+> An automated axe pass exists in `.github/workflows/ci.yml` but is **commented out** and points at a
+> non-existent `apps/portfolio`. Re-enabling it for `apps/blog` is worthwhile if you touch CI.

--- a/.cursor/bitsui-components.mdc
+++ b/.cursor/bitsui-components.mdc
@@ -1,0 +1,348 @@
+---
+description: Bits UI component library usage patterns for packages/ui
+globs:
+    - 'packages/ui/**/*.{svelte,ts}'
+    - 'apps/blog/**/*.svelte'
+alwaysApply: true
+docs:
+    - name: Bits UI Documentation (LLM-optimised)
+      url: https://bits-ui.com/llms.txt
+    - name: Bits UI Introduction
+      url: https://bits-ui.com/docs/introduction/llms.txt
+    - name: Bits UI State Management
+      url: https://bits-ui.com/docs/state-management/llms.txt
+    - name: Bits UI Styling Guide
+      url: https://bits-ui.com/docs/styling/llms.txt
+    - name: Bits UI Child Snippet (Render Delegation)
+      url: https://bits-ui.com/docs/child-snippet/llms.txt
+    - name: Bits UI mergeProps Utility
+      url: https://bits-ui.com/docs/utilities/merge-props/llms.txt
+---
+
+# Bits UI Component Patterns
+
+Bits UI is the headless component primitive layer for `packages/ui`. Components are **completely
+unstyled** — all styling is applied via Tailwind v4 utility classes. They provide accessible,
+keyboard-navigable behaviour out of the box.
+
+> **Never use UnoCSS.** This monorepo uses **Tailwind CSS v4** exclusively — see
+> [tailwind-styling.mdc](mdc:.cursor/tailwind-styling.mdc).
+
+`bits-ui` is a dependency of `packages/ui` only. Reach for it whenever you need an interactive
+widget — dialog, popover, select, tabs, accordion — instead of hand-rolling ARIA.
+
+## Core Philosophy
+
+- Components ship with **no CSS** — you own the styles entirely
+- **WAI-ARIA compliant** — keyboard navigation and screen reader support built-in
+- **Svelte 5 native** — uses runes, snippets, and the `child` snippet for render delegation
+- **Composable** — components are primitives, not black boxes
+
+## Installing & Importing
+
+```ts
+// In packages/ui components
+import { Dialog, Accordion } from 'bits-ui';
+
+// In apps/blog — always import the wrapper from the shared UI package
+import { Header, Card } from '@a11y.cool/ui';
+```
+
+Never import directly from `bits-ui` in `apps/blog`. Wrap Bits UI primitives in a
+`packages/ui/src/components/*.svelte` component and export it from `packages/ui/index.ts`.
+
+## Component Anatomy
+
+Every Bits UI component is composed of named sub-components (e.g. `Dialog.Root`, `Dialog.Trigger`,
+`Dialog.Content`). Access them via the named import.
+
+```svelte
+<script lang="ts">
+	import { Dialog } from 'bits-ui';
+</script>
+
+<Dialog.Root>
+	<Dialog.Trigger>Open</Dialog.Trigger>
+	<Dialog.Portal>
+		<Dialog.Overlay />
+		<Dialog.Content>
+			<Dialog.Title>Title</Dialog.Title>
+			<Dialog.Description>Description</Dialog.Description>
+			<Dialog.Close>Close</Dialog.Close>
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+```
+
+## Wrapping Bits UI in `packages/ui`
+
+Always wrap Bits UI primitives in a `packages/ui` component. Apply Tailwind classes with project
+tokens and expose a clean API. This repo has **no `cn()` helper** — merge with a `$derived` template
+string, `className` last:
+
+```svelte
+<!-- packages/ui/src/components/Dialog.svelte -->
+<script lang="ts">
+	import { Dialog } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+
+	let {
+		open = $bindable(false),
+		title,
+		description,
+		children,
+		trigger,
+		class: className = ''
+	}: {
+		open?: boolean;
+		title: string;
+		description?: string;
+		children: Snippet;
+		trigger: Snippet;
+		class?: string;
+	} = $props();
+
+	const contentClass = $derived(
+		`fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2
+		 bg-background rounded-card border border-border-input p-6 shadow-card
+		 data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out ${className}`
+	);
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Trigger>
+		{@render trigger()}
+	</Dialog.Trigger>
+	<Dialog.Portal>
+		<Dialog.Overlay
+			class="fixed inset-0 z-50 bg-dark/40 backdrop-blur-sm
+			       data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out"
+		/>
+		<Dialog.Content class={contentClass}>
+			<Dialog.Title class="text-lg font-semibold text-foreground">{title}</Dialog.Title>
+			{#if description}
+				<Dialog.Description class="mt-1 text-sm text-muted-foreground">
+					{description}
+				</Dialog.Description>
+			{/if}
+			<div class="mt-4">
+				{@render children()}
+			</div>
+			<Dialog.Close class="absolute right-4 top-4 text-muted-foreground hover:text-foreground" />
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+```
+
+Then add it to the root barrel:
+
+```ts
+// packages/ui/index.ts
+export { default as Dialog } from './src/components/Dialog.svelte';
+```
+
+## Styling Approach
+
+Bits UI adds `data-*` attributes to elements for state-based styling. Use these with Tailwind
+variants:
+
+```svelte
+<Accordion.Trigger
+	class="flex w-full items-center justify-between py-3 text-sm font-medium
+	       data-[state=open]:text-accent-foreground data-[disabled]:opacity-50"
+/>
+
+<Checkbox.Root
+	class="size-4 rounded-button border border-border-input
+	       data-[state=checked]:bg-dark data-[state=checked]:border-dark"
+/>
+```
+
+Common Bits UI data attributes:
+
+| Attribute | Values | When applied |
+|---|---|---|
+| `data-state` | `open` / `closed` | Toggleable components (dialog, accordion, etc.) |
+| `data-state` | `checked` / `unchecked` / `indeterminate` | Checkbox, Switch |
+| `data-disabled` | `""` | When `disabled` prop is set |
+| `data-highlighted` | `""` | Focused/hovered menu/select item |
+| `data-placeholder` | `""` | Select with no value |
+| `data-orientation` | `horizontal` / `vertical` | Oriented components |
+
+## Animations
+
+`tailwindcss-animate` is **not** installed. Do not write `animate-in`, `animate-out`, `fade-in-0`, or
+`zoom-in-95` — those classes do not exist here and produce nothing.
+
+Use the project's named animations from `@theme inline` in `packages/ui/src/styles/globals.css`:
+
+```svelte
+<!-- Fade (overlays, tooltips) -->
+class="data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out"
+
+<!-- Scale (dialogs, popovers) -->
+class="data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out"
+
+<!-- Slide (tabs, navigation menus) -->
+class="data-[state=open]:animate-enter-from-right data-[state=closed]:animate-exit-to-right"
+```
+
+### Height animations (Accordion, Collapsible)
+
+`animate-accordion-down` / `animate-accordion-up` already exist and read
+`--bits-accordion-content-height`, the CSS variable Bits UI measures for you:
+
+```svelte
+<Accordion.Content
+	class="overflow-hidden
+	       data-[state=open]:animate-accordion-down
+	       data-[state=closed]:animate-accordion-up"
+/>
+```
+
+Always define **both** the open and closed variant — the exit animation will not run otherwise.
+
+If you need a new animation, add `--animate-<name>` **and** its `@keyframes` inside the same
+`@theme inline` block in `globals.css`.
+
+### Transitions with the `child` snippet
+
+When you need Svelte's `transition:` directive instead of CSS animations:
+
+```svelte
+<!-- Floating content (Tooltip, Popover, Select, Dropdown) -->
+<Tooltip.Content>
+	{#snippet child({ wrapperProps, props, open })}
+		{#if open}
+			<div {...wrapperProps}>
+				<!-- wrapperProps handles positioning — NEVER style this div -->
+				<div {...props} transition:fade={{ duration: 150 }} class="…tooltip styles…">
+					Tooltip text
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</Tooltip.Content>
+
+<!-- Non-floating content (Dialog) -->
+<Dialog.Content>
+	{#snippet child({ props, open })}
+		{#if open}
+			<div {...props} transition:scale={{ start: 0.95, duration: 200 }}>Dialog content</div>
+		{/if}
+	{/snippet}
+</Dialog.Content>
+```
+
+> **Critical rule for floating components** (`Tooltip.Content`, `Popover.Content`, `Select.Content`,
+> `DropdownMenu.Content`, `Combobox.Content`):
+> - Always use the two-level structure: outer `{...wrapperProps}` + inner `{...props}`
+> - Never add styles or classes to the `wrapperProps` element — it handles positioning
+> - All styling goes on the inner `props` element
+
+## Render Delegation (child snippet)
+
+Use the `child` snippet to render a Bits UI component's behaviour onto a custom element:
+
+```svelte
+<Dialog.Trigger>
+	{#snippet child({ props })}
+		<Button {...props}>Open Dialog</Button>
+	{/snippet}
+</Dialog.Trigger>
+```
+
+This passes all accessibility attributes (`aria-*`, `data-*`, event handlers) to your own component.
+
+## Controlled vs Uncontrolled State
+
+```svelte
+<!-- Uncontrolled — component manages its own open state -->
+<Dialog.Root>…</Dialog.Root>
+
+<!-- Controlled — parent manages state -->
+<script lang="ts">
+	let isOpen = $state(false);
+</script>
+<Dialog.Root bind:open={isOpen}>…</Dialog.Root>
+```
+
+## Event Callbacks
+
+Use `on*` callback props instead of DOM events for Bits UI state changes:
+
+```svelte
+<Select.Root
+	onValueChange={(value) => (selectedValue = value)}
+	onOpenChange={(open) => {
+		if (!open) {
+			validate();
+		}
+	}}
+/>
+```
+
+## Choosing the Right Primitive
+
+| Component need | Bits UI import |
+|---|---|
+| Modal / confirmation | `Dialog` |
+| Dropdown actions menu | `DropdownMenu` |
+| Contextual floating panel | `Popover` |
+| Hover tooltip | `Tooltip` |
+| List selection (single/multi) | `Select` |
+| Filterable list | `Combobox` |
+| Expand/collapse | `Accordion` or `Collapsible` |
+| Horizontal sections | `Tabs` |
+| Binary toggle | `Switch` |
+| Checkbox (tri-state) | `Checkbox` |
+| Group of exclusive options | `RadioGroup` |
+| Searchable command menu | `Command` |
+| Right-click menu | `ContextMenu` |
+| Navigation links | `NavigationMenu` |
+| Progress indicator | `Progress` |
+| Range selector | `Slider` |
+
+## mergeProps Utility
+
+When composing event handlers from multiple sources, use `mergeProps` to safely combine them:
+
+```svelte
+<script lang="ts">
+	import { mergeProps } from 'bits-ui';
+
+	let { ...restProps } = $props();
+
+	function handleClick() {
+		/* local logic */
+	}
+</script>
+
+<Button.Root {...mergeProps(restProps, { onclick: handleClick })}>Click</Button.Root>
+```
+
+## Accessibility Rules
+
+- Never remove `aria-*` props from Bits UI components — they are required for accessibility
+- `Dialog.Title` and `Dialog.Description` are required for screen readers; use `aria-label` on
+  `Dialog.Root` only as a fallback
+- Always test keyboard navigation: Tab, Escape, Enter, Space, Arrow keys
+- Use `Dialog.Portal` to render overlays at the document root (avoids z-index and overflow issues)
+- Never suppress the focus ring — this is an accessibility project. See
+  [accessibility.mdc](mdc:.cursor/accessibility.mdc).
+
+## Anti-Patterns
+
+```svelte
+<!-- ❌ Never override data-* attributes Bits UI manages -->
+<Dialog.Content data-state="open">…</Dialog.Content>
+
+<!-- ❌ Never strip focus styling without providing a visible replacement -->
+<Select.Item class="outline-none ring-0">…</Select.Item>
+
+<!-- ❌ Never import bits-ui directly in apps/blog -->
+import { Dialog } from 'bits-ui'; // in apps/blog — WRONG
+
+<!-- ❌ Never use tailwindcss-animate class names — not installed -->
+<Dialog.Content class="data-[state=open]:animate-in data-[state=open]:zoom-in-95" />
+```

--- a/.cursor/claude-context.md
+++ b/.cursor/claude-context.md
@@ -1,0 +1,20 @@
+# Claude Context Index
+
+This file exists as a lightweight Claude-facing index for Cursor rule files.
+The canonical rule definitions live in `.cursor/*.mdc`.
+
+When working in this repository with Claude Code, reference these rule files directly:
+
+- `@.cursor/monorepo.mdc`
+- `@.cursor/svelte.mdc`
+- `@.cursor/typescript-style.mdc`
+- `@.cursor/tailwind-styling.mdc`
+- `@.cursor/bitsui-components.mdc`
+- `@.cursor/ghost-directus-data.mdc`
+- `@.cursor/accessibility.mdc`
+- `@.cursor/git-policy.mdc`
+- `@.cursor/cursor-rules.mdc`
+- `@.cursor/self-improve.mdc`
+
+The legacy `.cursorrules` file at the repo root is a generic Svelte 5 runes reference.
+`.cursor/svelte.mdc` supersedes it for project-specific guidance.

--- a/.cursor/cursor-rules.mdc
+++ b/.cursor/cursor-rules.mdc
@@ -1,0 +1,140 @@
+---
+description: How to add or edit Cursor rules in this project
+alwaysApply: false
+---
+
+# Cursor Rules Management Guide
+
+## Rule Structure Format
+
+Every cursor rule must follow this exact metadata and content structure:
+
+````markdown
+---
+description: Short description of the rule's purpose
+globs: optional/path/pattern/**/*
+alwaysApply: false
+---
+
+# Rule Title
+
+Main content explaining the rule with markdown formatting.
+
+1. Step-by-step instructions
+2. Code examples
+3. Guidelines
+
+Example:
+
+```typescript
+// Good
+function goodExample() {
+	// Correct implementation
+}
+
+// Bad example
+function badExample() {
+	// Incorrect implementation
+}
+```
+````
+
+## File Organization
+
+### Required Location
+
+All cursor rule files **must** be placed in:
+
+```
+PROJECT_ROOT/.cursor/
+```
+
+### Directory Structure
+
+```
+PROJECT_ROOT/
+├── .cursor/
+│   ├── your-rule-name.mdc
+│   ├── another-rule.mdc
+│   └── cursor-rules.mdc
+└── ...
+```
+
+### Naming Conventions
+
+- Use **kebab-case** for all filenames
+- Always use **.mdc** extension
+- Make names **descriptive** of the rule's purpose
+- Examples: `typescript-style.mdc`, `tailwind-styling.mdc`, `ghost-directus-data.mdc`
+
+## Content Guidelines
+
+### Writing Effective Rules
+
+1. **Be specific and actionable** - Provide clear instructions
+2. **Include code examples** - Show both good and bad practices
+3. **Reference existing files** - Use `@filename.ext` format
+4. **Keep it focused** - One rule per concern/pattern
+5. **Add context** - Explain why the rule exists
+
+### Code Examples Format
+
+```typescript
+// ✅ Good: Clear and follows conventions
+function processUser({ id, name }: { id: string; name: string }) {
+	return { id, displayName: name };
+}
+
+// ❌ Bad: Unclear parameter passing
+function processUser(id: string, name: string) {
+	return { id, displayName: name };
+}
+```
+
+### File References
+
+When referencing project files in rules, use this pattern to mention other files:
+
+```markdown
+[file.ts](mdc:path/to/file.ts)
+```
+
+## Forbidden Locations
+
+**Never** place rule files in:
+
+- Project root directory
+- Any subdirectory outside `.cursor/`
+- Component directories
+- Source code folders
+- Documentation folders
+
+## Rule Categories
+
+Organize rules by purpose:
+
+- **Code Style**: `typescript-style.mdc`, `tailwind-styling.mdc`
+- **Architecture**: `monorepo.mdc`, `bitsui-components.mdc`
+- **Data**: `ghost-directus-data.mdc`
+- **Quality**: `accessibility.mdc`
+- **Meta**: `cursor-rules.mdc`, `self-improve.mdc`
+
+## Best Practices
+
+### Rule Creation Checklist
+
+- [ ] File placed in `.cursor/` directory
+- [ ] Filename uses kebab-case with `.mdc` extension
+- [ ] Includes proper metadata section
+- [ ] Contains clear title and sections
+- [ ] Provides both good and bad examples
+- [ ] References relevant project files
+- [ ] Follows consistent formatting
+- [ ] Added to the index in [claude-context.md](mdc:.cursor/claude-context.md)
+
+### Maintenance
+
+- **Review regularly** - Keep rules up to date with codebase changes
+- **Update examples** - Ensure code samples reflect current patterns
+- **Cross-reference** - Link related rules together
+- **Document changes** - Update rules when patterns evolve

--- a/.cursor/ghost-directus-data.mdc
+++ b/.cursor/ghost-directus-data.mdc
@@ -1,0 +1,216 @@
+---
+description: Ghost + Directus data layer — structure, types, queries, and consumption in SvelteKit
+alwaysApply: true
+globs:
+    - 'packages/data/**/*.ts'
+    - 'apps/blog/src/routes/**/+*.server.ts'
+docs:
+    - name: Ghost Content API
+      url: https://ghost.org/docs/content-api/
+    - name: Directus GraphQL API
+      url: https://directus.io/docs/guides/connect/query-parameters
+---
+
+# Ghost + Directus Data Layer
+
+This project has **no CMS app in the repo**. Content comes from two hosted services, both accessed
+exclusively through `packages/data`:
+
+| Source | What it holds | Client |
+|---|---|---|
+| **Ghost** | Blog posts, authors, tags | `packages/data/src/ghost/ghost.api.ts` (`@tryghost/content-api`) |
+| **Directus** | Home, About, and static pages (imprint, privacy policy) | `packages/data/src/directus/directus.api.ts` (GraphQL over `fetch`) |
+
+## Architecture
+
+```
+packages/data/src/
+├── ghost/
+│   └── ghost.api.ts        ← Ghost Content API client, mappers, getPosts/getPost
+├── directus/
+│   └── directus.api.ts     ← GraphQL query strings, directusFetch, getHome/getAbout/getPage
+├── types/
+│   ├── post.type.ts        ← Post, Author, Tag (Ghost, mapped)
+│   ├── home.type.ts        ← Home (Directus)
+│   ├── about.type.ts       ← About (Directus)
+│   └── page.type.ts        ← Page (Directus)
+├── default/
+│   └── metaDefault.data.ts ← defaultMetaTags(url)
+└── index.ts                ← public barrel export
+```
+
+## Golden Rule: Types Always Live in `packages/data/src/types`
+
+> **NEVER** declare shared types inside `apps/blog/src/`, `packages/ui`, or `packages/utils`.
+> **ALWAYS** add them to `packages/data/src/types/*.type.ts` and export them from the barrel.
+
+```ts
+// ✅ Correct
+import type { Post, Author } from '@a11y.cool/data';
+
+// ❌ Wrong — never define a shared shape locally in the app
+interface Post { … }
+```
+
+## The Degradation Contract
+
+Both clients are **optional at runtime**. If the env vars are missing or the service is unreachable,
+the fetcher logs a warning and returns an empty array / `null` — it never throws. This is what keeps
+the site buildable and previewable without CMS credentials.
+
+Every new fetcher must follow the same shape:
+
+```ts
+export const getThing = async (): Promise<Thing | null> => {
+	if (!apiUrl || !apiToken) {
+		console.warn('Directus API is not configured; skipping data fetch.');
+		return null;
+	}
+
+	try {
+		const data = (await directusFetch(dataQueryThing)) as { thing: Thing } | null;
+		return data?.thing ?? null;
+	} catch (err) {
+		console.warn('Failed to fetch thing from Directus API:', err);
+		return null;
+	}
+};
+```
+
+The **route** decides what missing data means — `error(404, …)` for a missing post, a rendered empty
+state for missing page copy. The data layer never makes that call.
+
+## Ghost Conventions
+
+Ghost's API types are loose, so `ghost.api.ts` maps every response into the project's own `Post` /
+`Author` / `Tag` shapes. Consumers must only ever see the mapped type.
+
+```ts
+// Ghost field  →  project field
+post.id            → _id
+post.html          → content
+post.feature_image → coverImage
+post.published_at  → publishedAt
+post.reading_time  → readingTime
+```
+
+Rules:
+
+- Always request `include: ['tags', 'authors']` when the UI shows either
+- Always list explicit `fields` on `browse()` — do not fetch the whole document
+- Filter incomplete records before mapping (`post?.id && post?.title && post?.slug && post?.html`)
+- Add new fields to the mapper **and** to `post.type.ts` in the same change
+- `isGhostConfigured()` is the guard — use it, do not re-read env vars at the call site
+
+## Directus Conventions
+
+Directus is queried with hand-written GraphQL strings, one exported `const` per query.
+
+```ts
+export const dataQueryAbout: string = `query {
+    about {
+        id
+        title
+        about_intro
+        members {
+            name
+            image { id description }
+        }
+    }
+}`;
+```
+
+Rules:
+
+- Query naming: `dataQuery<Collection>` for a static query, `dataQuery<Collection>(arg)` for a
+  parameterised one
+- Getter naming: `get<Collection>()` returning the mapped type or `null`
+- Request only the fields the UI renders
+- `directusFetch` already surfaces GraphQL `errors` and non-OK statuses as a warning + `null` —
+  do not duplicate that handling in a getter
+- Images are UUID references; build URLs with `mediaUrl(uuid)`, which defaults to `?format=webp`
+
+> **Note:** `directus.api.ts` also exports older `request()` / `getData()` helpers that read
+> `process.env.API_URL` / `API_TOKEN` (no `VITE_` prefix) and throw on failure. They predate
+> `directusFetch` and are not used by the current getters. Prefer `directusFetch`; do not extend the
+> old pair.
+
+## Untrusted HTML
+
+Ghost post bodies and Directus rich text are **untrusted HTML**. Never pass them to `{@html}`.
+
+```svelte
+<script lang="ts">
+	import { processHtml } from '@a11y.cool/utils'; // rehype-parse + rehype-sanitize
+	import { HtmlRender } from '@a11y.cool/ui';
+
+	let { data } = $props();
+	let ast = $derived(processHtml(data.post?.content));
+</script>
+
+{#if ast}
+	<div class="prose prose-lg max-w-none">
+		<HtmlRender node={ast} />
+	</div>
+{/if}
+```
+
+`HtmlRender` walks the sanitized hast tree and renders real Svelte elements (delegating `<pre><code>`
+to `CodeRender` for highlight.js). This is also what keeps the strict CSP in `+layout.server.ts`
+satisfiable.
+
+## Consuming Data in SvelteKit
+
+All CMS access happens in `+page.server.ts` / `+layout.server.ts` — the clients read `process.env`
+and must never reach the browser.
+
+```ts
+// apps/blog/src/routes/blog/[slug]/+page.server.ts
+import type { PageServerLoad } from './$types';
+import type { MetaTagsProps } from 'svelte-meta-tags';
+import { getPost } from '@a11y.cool/data';
+import { error } from '@sveltejs/kit';
+
+export const load = (async ({ params }) => {
+	const post = await getPost(params.slug);
+
+	if (!post) {
+		error(404, 'Post not found');
+	}
+
+	const pageMetaTags = {
+		title: `${post.title} — Blog`,
+		description: post.excerpt || 'Read this article on Accessibility.cool'
+	} satisfies MetaTagsProps;
+
+	return { post, pageMetaTags };
+}) satisfies PageServerLoad;
+```
+
+Site-wide data (`home`, `about`, `baseMetaTags`, nav) is loaded once in `+layout.server.ts` — read it
+from `page.data` rather than re-fetching per route.
+
+## Environment Variables
+
+| Variable | Service | Read in |
+|---|---|---|
+| `VITE_GHOST_API_URL` | Ghost | `ghost.api.ts` |
+| `VITE_GHOST_CONTENT_API_KEY` | Ghost | `ghost.api.ts` |
+| `VITE_API_URL` | Directus | `directus.api.ts` |
+| `VITE_API_TOKEN` | Directus | `directus.api.ts` |
+| `PUBLIC_BLOG_ENABLED` | app feature flag | `$lib/features.ts` via `$env/dynamic/public` |
+
+Never commit real tokens. Despite the `VITE_` prefix these are read server-side via `dotenv` in
+`packages/data` — they are **not** exposed to the client, and must not be moved to
+`$env/dynamic/public`.
+
+## Checklist: Adding a New Content Type
+
+1. **`packages/data/src/types/`** — create `<name>.type.ts` with the interface
+2. **`packages/data/src/{ghost,directus}/`** — add the query string and a `get<Name>()` getter
+   following the degradation contract
+3. **`packages/data/src/index.ts`** — export the new type file from the barrel
+4. **`apps/blog/src/routes/…/+page.server.ts`** — load it, return `pageMetaTags` alongside
+5. **`apps/blog/src/routes/…/+page.svelte`** — render with components from `@a11y.cool/ui`; sanitize
+   any HTML through `processHtml`
+6. Verify: `pnpm --filter a11y.cool-website check && pnpm lint`

--- a/.cursor/git-policy.mdc
+++ b/.cursor/git-policy.mdc
@@ -1,0 +1,26 @@
+---
+description: Git permissions — what the AI is and is not allowed to do with git
+alwaysApply: true
+---
+
+# Git Policy
+
+Claude and Cursor are allowed to use git, including committing, pushing, and
+creating pull requests.
+
+## Branches
+
+- `dev` is the integration branch — feature work and dependency updates land here first.
+- `main` is fast-forwarded from `dev`; it is checked out in a **separate worktree** at
+  `/Users/simon/Development/accessibility.cool/blog`, so `git checkout main` fails in other
+  worktrees. Push the ref directly (`git push origin dev:main`) instead.
+- Create PRs against `dev` unless the user says otherwise.
+
+## Guidelines
+
+- Commit and push when the user asks.
+- Write clear, scoped commit messages.
+- Avoid history-rewriting operations (`git reset --hard`, `git rebase`,
+  `git push --force` to shared branches) unless the user explicitly asks.
+- Never force-push `main` or `dev`. If a fast-forward is not possible, stop and report.
+- Don't rename the current branch unless the user explicitly tells you to.

--- a/.cursor/monorepo.mdc
+++ b/.cursor/monorepo.mdc
@@ -1,0 +1,112 @@
+---
+description: Monorepo (Turborepo) structure guide for the a11y.cool project
+alwaysApply: true
+docs:
+    - name: Turborepo Documentation
+      url: https://turborepo.dev/llms.txt
+    - name: Turborepo SvelteKit Guide
+      url: https://turborepo.dev/guides/frameworks/sveltekit.md
+    - name: Turborepo Managing Dependencies
+      url: https://turborepo.dev/crafting-your-repository/managing-dependencies.md
+---
+
+# Monorepo Guideline
+
+## Monorepo Structure
+
+This is a Turborepo monorepo with pnpm workspaces. **Always respect these package boundaries:**
+
+```
+apps/
+  blog/                        SvelteKit 2 + Svelte 5 app (Netlify) — package name: a11y.cool-website
+    src/
+      routes/                  SvelteKit file-based routing
+      lib/                     $lib alias — app-local helpers (features.ts: nav + feature flags)
+      global.css               Tailwind v4 entry + @a11y.cool/ui globals
+      app.d.ts                 App.Locals, App.PageData type augmentation
+      hooks.server.ts          Route gating (blog feature flag)
+    svelte.config.js           adapter-netlify
+    vite.config.ts             sveltekit() + tailwindcss() + devtoolsJson()
+
+packages/
+  data/                        Shared types + CMS clients — the single source of truth
+    src/
+      types/                   All shared TypeScript types (*.type.ts)
+      ghost/ghost.api.ts       Ghost Content API client (blog posts)
+      directus/directus.api.ts Directus GraphQL client + queries (home, about, pages)
+      default/                 metaDefault.data.ts — default meta tags
+      index.ts                 Public barrel export
+
+  ui/                          Shared Svelte 5 component library
+    index.ts                   Root barrel — named re-exports of every component
+    src/
+      components/              Flat: [Component].svelte (Svelte 5 runes, Tailwind classes)
+      styles/                  globals.css (tokens + @theme inline), fonts.css, typography.css,
+                               code-themes/{a11y-dark,a11y-light}.css
+      fonts/                   @font-face .woff2 assets
+    postcss.config.mjs
+
+  utils/                       Shared pure utility functions (no Svelte/SvelteKit)
+    index.ts                   Barrel
+    src/                       animation.ts, global-utils.ts, html.ts
+
+  eslint-config/               Shared ESLint flat config (exports `config`)
+  typescript-config/           Shared tsconfig (svelte.json) consumed by all apps and packages
+```
+
+There is **one app** (`apps/blog`). Do not assume a second app, a CMS app, or a design app exists.
+
+## Critical Import Rules
+
+| What you need | Import from |
+|---|---|
+| Shared types, interfaces, Ghost/Directus clients and queries | `@a11y.cool/data` |
+| UI components | `@a11y.cool/ui` |
+| Shared pure utilities (functions only — no shared types) | `@a11y.cool/utils` |
+| App-local helpers (feature flags, nav) | `$lib/` (local to `apps/blog`) |
+
+- **Never** import `.svelte` files directly across package boundaries — always use the `index.ts` barrel
+  (the one exception is the declared `./components/*` subpath export, used only when a barrel import
+  would create a cycle)
+- **Never** define shared types or interfaces inside `apps/*`, `packages/ui`, or `packages/utils` — add
+  them to `packages/data/src/types/*.type.ts` and export them from `packages/data/src/index.ts`
+- **Exception:** SvelteKit-generated `./$types`, plus `App.Locals` / `App.PageData` augmentation in
+  `apps/blog/src/app.d.ts`, and app-local shapes used by one module only (e.g. `NavItem` in `$lib/features.ts`)
+- **Never** read API tokens (`VITE_API_TOKEN`, `VITE_GHOST_CONTENT_API_KEY`) in browser-side code —
+  the CMS clients in `packages/data` are consumed from `+page.server.ts` / `+layout.server.ts` only
+
+## Key Commands
+
+```bash
+pnpm dev              # run the app via turbo
+pnpm build            # build packages then apps (dependency order inferred)
+pnpm check-types      # TypeScript check (see gap below)
+pnpm lint             # ESLint across all workspaces that define a lint task
+pnpm format           # Prettier format
+pnpm update-deps      # ./update-deps.sh — see .claude/skills/update-deps
+
+# Target a specific package
+pnpm --filter a11y.cool-website dev
+pnpm --filter @a11y.cool/ui lint
+pnpm --filter a11y.cool-website check
+```
+
+> **Known gap:** only `apps/blog` defines a `check-types` script, so `pnpm check-types` does not
+> type-check `packages/*`. `pnpm --filter a11y.cool-website check` (svelte-check) is the broader
+> signal. When you add a `check-types` script to a package, it is picked up by `turbo.json` automatically.
+
+## turbo.json Task Graph
+
+Tasks flow in dependency order: `packages/*` tasks run before `apps/*` tasks. `build`, `lint`, and
+`check-types` all declare `dependsOn: ["^<task>"]`.
+
+## Netlify Deployment
+
+`apps/blog` targets Netlify via `@sveltejs/adapter-netlify`. Security headers and CSP are set in
+`apps/blog/src/routes/+layout.server.ts` — update them there, not in `netlify.toml`.
+
+## Feature Flags
+
+The blog section is gated by `PUBLIC_BLOG_ENABLED` (read via `$env/dynamic/public` in
+`$lib/features.ts`). `hooks.server.ts` returns 404 for `/blog/*` when it is off, and `getNavItems()`
+hides the nav entry. Keep both in sync when adding a gated section.

--- a/.cursor/self-improve.mdc
+++ b/.cursor/self-improve.mdc
@@ -1,0 +1,84 @@
+---
+description: Guidelines for continuously improving Cursor rules based on emerging code patterns and best practices.
+globs:
+alwaysApply: true
+---
+
+# Self-Improvement
+
+This rule explains how to continuously improve Cursor rules based on emerging code patterns and best practices.
+
+## Rule Improvement Triggers
+
+- New code patterns not covered by existing rules
+- Repeated similar implementations across files
+- Common error patterns that could be prevented
+- New libraries or tools being used consistently
+- Emerging best practices in the codebase
+
+## Analysis Process
+
+- Compare new code with existing rules
+- Identify patterns that should be standardized
+- Look for references to external documentation
+- Check for consistent error handling patterns
+- Monitor test patterns and coverage
+
+## Rule Updates
+
+- **Add New Rules When:**
+    - A new technology/pattern is used in 3+ files
+    - Common bugs could be prevented by a rule
+    - Code reviews repeatedly mention the same feedback
+    - New security or accessibility patterns emerge
+
+- **Modify Existing Rules When:**
+    - Better examples exist in the codebase
+    - Additional edge cases are discovered
+    - Related rules have been updated
+    - Implementation details have changed
+
+- **Example Pattern Recognition:**
+
+    ```typescript
+    // If you see repeated patterns like:
+    const data = await directusFetch(dataQueryHome);
+    if (!data) {
+    	return null;
+    }
+
+    // Consider adding to [ghost-directus-data.mdc](mdc:.cursor/ghost-directus-data.mdc):
+    // - Standard null-on-failure contract
+    // - Required env-var guard
+    // - Where the mapped type lives
+    ```
+
+- **Rule Quality Checks:**
+- Rules should be actionable and specific
+- Examples should come from actual code
+- References should be up to date
+- Patterns should be consistently enforced
+
+## Continuous Improvement
+
+- Monitor code review comments
+- Track common development questions
+- Update rules after major refactors
+- Add links to relevant documentation
+- Cross-reference related rules
+
+## Rule Deprecation
+
+- Mark outdated patterns as deprecated
+- Remove rules that no longer apply
+- Update references to deprecated rules
+- Document migration paths for old patterns
+
+## Documentation Updates
+
+- Keep examples synchronized with code
+- Update references to external docs
+- Maintain links between related rules
+- Document breaking changes
+
+Follow [cursor-rules.mdc](mdc:.cursor/cursor-rules.mdc) for proper rule formatting and structure.

--- a/.cursor/svelte.mdc
+++ b/.cursor/svelte.mdc
@@ -1,0 +1,437 @@
+---
+description: Svelte 5 and SvelteKit 2 best practices for the a11y.cool monorepo
+globs:
+    - 'apps/blog/**/*.{svelte,ts,js}'
+    - 'packages/ui/**/*.{svelte,ts,js}'
+    - 'packages/data/**/*.ts'
+    - 'packages/utils/**/*.ts'
+alwaysApply: true
+docs:
+    - name: Svelte & SvelteKit Documentation (LLM-optimised)
+      url: https://svelte.dev/llms-full.txt
+    - name: Bits UI Documentation (LLM-optimised)
+      url: https://bits-ui.com/llms.txt
+---
+
+# Svelte
+
+This rule explains how to correctly use Svelte/SvelteKit and related technologies.
+You are an expert TypeScript, Svelte 5, SvelteKit 2, Bits UI, and Tailwind CSS v4 engineer. You write
+idiomatic, type-safe, accessible, and performant code. You always use Svelte 5 runes. You never
+regress to Svelte 4 APIs (`$:`, `export let`, `createEventDispatcher`, `<slot>`) unless explicitly
+told to maintain a legacy file.
+
+> **Never use UnoCSS.** This monorepo uses **Tailwind CSS v4** exclusively — see
+> [tailwind-styling.mdc](mdc:.cursor/tailwind-styling.mdc).
+
+## Code Style and Structure
+
+- Write concise, technical TypeScript code using the rules below
+- Use functional and declarative programming patterns; avoid classes
+- Prefer iteration and modularization over code duplication
+- Use descriptive variable names with auxiliary verbs (e.g. `isLoading`, `hasError`)
+- Structure files: exported component, subcomponents, helpers, static content
+
+## Rules
+
+- No unused variables.
+- For multi-line if statements, use curly braces.
+- Always handle the error parameter in try/catch blocks.
+- Use camelCase for variables and functions.
+- Use PascalCase for constructors and Svelte components.
+
+## Naming Conventions
+
+- Use lowercase with dashes for directories (e.g. `routes/privacy-policy`)
+- Use named exports; the only default exports are `.svelte` component files
+
+## UI and Styling
+
+- Use Bits UI for interactive component foundations, wrapped in `packages/ui/src/components`
+- Implement responsive design with Tailwind v4; mobile-first
+- Use Tailwind utility classes with project design tokens — **never UnoCSS**, never raw hex
+- Dark mode is token-driven via `prefers-color-scheme` — see [tailwind-styling.mdc](mdc:.cursor/tailwind-styling.mdc)
+
+## Error Handling and Validation
+
+- Prioritize error handling and edge cases.
+- Handle errors and edge cases at the beginning of functions.
+- Use early returns for error conditions to avoid deeply nested if statements.
+- Place the happy path last in the function for improved readability.
+- Avoid unnecessary else statements; use the if-return pattern instead.
+- Use guard clauses to handle preconditions and invalid states early.
+- Implement proper error logging and user-friendly error messages.
+
+## Security
+
+- Sanitize user inputs to prevent XSS attacks.
+- CMS HTML (Ghost post bodies, Directus rich text) is **untrusted**. Never pass it to `{@html}`
+  directly — run it through `processHtml()` from `@a11y.cool/utils` (rehype-sanitize) and render the
+  resulting hast tree via the `HtmlRender` component from `@a11y.cool/ui`.
+- Security headers and the CSP live in `apps/blog/src/routes/+layout.server.ts`. Adding an inline
+  script or a third-party origin requires updating the CSP there.
+
+## Import Rules
+
+- Import shared types, Ghost/Directus clients and queries from `@a11y.cool/data`
+- Import UI components from `@a11y.cool/ui`
+- Import pure helpers from `@a11y.cool/utils`
+- Import app-local helpers from `$lib/`
+- Never import from `apps/blog` inside any `packages/` folder
+- Never import `.svelte` files directly across package boundaries — use the `index.ts` barrel
+
+## Svelte 5 Runes
+
+### State — $state
+
+```ts
+// Primitive state
+let count = $state(0);
+
+// Object state — deep reactive by default
+let user = $state({ name: '', role: '' });
+
+// Typed array state
+let items = $state<string[]>([]);
+
+// Large non-reactive list — skips deep proxy overhead
+let bigList = $state.raw<HeavyObject[]>([]);
+
+// Snapshot of current value — plain object, not reactive
+const snap = $state.snapshot(user);
+```
+
+Do not use `writable()` for local component state. Do not use `let x; $: x = ...`.
+
+### Derived State — $derived
+
+```ts
+// Simple expression
+let doubled = $derived(count * 2);
+
+// Complex computation
+let filtered = $derived.by(() => {
+	return items.filter((i) => i.startsWith('a')).length;
+});
+
+// Derived from props — the standard class-merging pattern in this repo
+let { variant = 'default', class: className = '' } = $props();
+let buttonClass = $derived(`inline-flex items-center ${variants[variant]} ${className}`);
+```
+
+Do not use `$: derived = someComputation()` in Svelte 5.
+
+`$derived` holds a **value**, not a getter. Do not wrap the expression in an arrow function and then
+call it — that returns a new function identity on every read and defeats the fine-grained
+dependency tracking.
+
+```ts
+// ❌ Bad — `post` is a function; every `post()` call re-runs the body
+let post = $derived(() => data?.post);
+{#if post()}<h1>{post().title}</h1>{/if}
+
+// ✅ Good
+let post = $derived(data?.post);
+{#if post}<h1>{post.title}</h1>{/if}
+```
+
+Use `$derived.by()` when the derivation genuinely needs multiple statements — that is the supported
+way to run a block, not `$derived(() => {...})`.
+
+### Effects — $effect
+
+```ts
+// Runs after every reactive dependency change
+$effect(() => {
+	console.log('count:', count);
+});
+
+// Effect with cleanup
+$effect(() => {
+	const id = setInterval(() => count++, 1000);
+	return () => clearInterval(id);
+});
+
+// Runs before DOM updates — use for measurement or scroll position
+$effect.pre(() => {
+	// measure DOM here
+});
+```
+
+Do not trigger side effects from `$derived`. Be cautious writing to state inside `$effect` — it can
+cause infinite loops. Prefer a Svelte **action** (`use:`) over `$effect` for DOM-lifecycle work; see
+`animate` in `packages/utils/src/animation.ts`.
+
+### Props — $props
+
+```ts
+// Typed destructured props
+let {
+	title,
+	description = 'Default',
+	onClose
+}: {
+	title: string;
+	description?: string;
+	onClose: () => void;
+} = $props();
+
+// Rest props for spreading onto a root element
+let { class: className = '', ...rest }: { class?: string; [key: string]: unknown } = $props();
+
+// Snippet props — replace slots
+import type { Snippet } from 'svelte';
+let {
+	children,
+	header
+}: {
+	children?: Snippet;
+	header?: Snippet<[string]>;
+} = $props();
+
+// Two-way bindable prop
+let { value = $bindable('') }: { value?: string } = $props();
+```
+
+Do not use `export let` in Svelte 5.
+
+### Snippets — Replace Slots
+
+Snippets replace `<slot>` entirely. Always use snippets for composable UI in `packages/ui`.
+
+```svelte
+<!-- Pass snippets as props to a component -->
+<Card title="Hello">
+	{#snippet image()}
+		<img src="/x.webp" alt="" />
+	{/snippet}
+</Card>
+```
+
+Snippets can take parameters — used in this repo for icon slots that receive their own classes:
+
+```svelte
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	type IconSnippet = Snippet<[{ class?: string; 'aria-hidden'?: string }]>;
+	let { leftIcon }: { leftIcon?: IconSnippet } = $props();
+</script>
+
+{#if leftIcon}
+	{@render leftIcon({ class: 'mr-2 h-4 w-4', 'aria-hidden': 'true' })}
+{/if}
+```
+
+### Dynamic Components
+
+```svelte
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import type { IconComponentProps } from 'phosphor-svelte';
+	let { iconComponent }: { iconComponent?: Component<IconComponentProps> } = $props();
+</script>
+
+{#if iconComponent}
+	{@const Icon = iconComponent}
+	<Icon size="24" aria-label="…" />
+{/if}
+```
+
+`<svelte:component>` is deprecated in Svelte 5 — assign to a capitalised local and render it.
+
+### Debugging — $inspect
+
+```ts
+$inspect(count); // dev-only reactive logger — stripped in production
+```
+
+## TypeScript Rules
+
+### Component Props Typing
+
+```ts
+// Use ComponentProps to type external component references
+import type { ComponentProps } from 'svelte';
+import { Button } from '@a11y.cool/ui';
+type ButtonProps = ComponentProps<typeof Button>;
+
+// Explicit return types on handlers
+function handleClick(e: MouseEvent): void {}
+
+// Generic $state when type is not inferrable
+let data = $state<Post | null>(null);
+```
+
+### SvelteKit Route Types
+
+Always import from `./$types` — never type load functions manually.
+
+```ts
+// +page.server.ts — the repo's established pattern uses `satisfies`
+import type { PageServerLoad } from './$types';
+import type { MetaTagsProps } from 'svelte-meta-tags';
+import { getPost } from '@a11y.cool/data';
+import { error } from '@sveltejs/kit';
+
+export const load = (async ({ params }) => {
+	const post = await getPost(params.slug);
+
+	if (!post) {
+		error(404, 'Post not found');
+	}
+
+	const pageMetaTags = {
+		title: `${post.title} — Blog`,
+		description: post.excerpt || 'Read this article on Accessibility.cool'
+	} satisfies MetaTagsProps;
+
+	return { post, pageMetaTags };
+}) satisfies PageServerLoad;
+```
+
+```ts
+// +server.ts
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+	return new Response('…', { headers: { 'Content-Type': 'application/xml' } });
+};
+```
+
+### App Type Augmentation
+
+Keep `apps/blog/src/app.d.ts` up to date when you add `locals` or shared page data:
+
+```ts
+declare global {
+	namespace App {
+		interface Locals {}
+		interface PageData {}
+		interface Error {}
+	}
+}
+
+export {};
+```
+
+## SvelteKit Routing and Data
+
+### Server-only by default
+
+All CMS access in this repo happens in `+page.server.ts` / `+layout.server.ts`, because the Ghost and
+Directus clients read tokens from `process.env`. Do not move a CMS call into `+page.ts`.
+
+### Meta tags
+
+SEO uses `svelte-meta-tags`. `+layout.server.ts` returns `baseMetaTags` from
+`defaultMetaTags(url)`; each page returns `pageMetaTags` and they are merged in `+layout.svelte`.
+Return a `pageMetaTags` object from every new page's load function.
+
+### Streaming Deferred Data
+
+Return a Promise without awaiting it — SvelteKit streams it to the client:
+
+```ts
+export const load: PageServerLoad = async () => {
+	return {
+		eager: await getEagerData(),
+		slow: getSlowData() // not awaited — streamed
+	};
+};
+```
+
+### Navigation
+
+```ts
+import { goto, invalidate, invalidateAll } from '$app/navigation';
+await goto('/blog', { replaceState: true });
+```
+
+## Shared State (.svelte.ts Modules)
+
+For state shared across components or pages, use a `.svelte.ts` module with runes instead of stores.
+
+```ts
+// apps/blog/src/lib/state/theme.svelte.ts
+let value = $state<'light' | 'dark'>('light');
+
+export function getTheme() {
+	return value;
+}
+
+export function setTheme(next: 'light' | 'dark') {
+	value = next;
+}
+```
+
+Only use Svelte stores for third-party library interop.
+
+## packages/ui Component Conventions
+
+Components are **flat files** in `packages/ui/src/components/`, re-exported from the package-root
+`index.ts`. There is no folder-per-component structure and no `cn()` helper.
+
+```
+packages/ui/
+  index.ts                     ← root barrel
+  src/components/
+    Button.svelte
+    Card.svelte
+    …
+```
+
+```ts
+// packages/ui/index.ts — add one line per new component
+export { default as Button } from './src/components/Button.svelte';
+```
+
+Component conventions:
+
+- Accept a `class` prop, default it to `''`, and append it **last** in a `$derived` template string
+  so callers can override
+- Spread `...props` onto the root element for HTML attribute passthrough
+- Use snippets, not slots; guard optional snippets with `{#if}` or `{@render children?.()}`
+- Never hardcode colors — always use design tokens (`bg-background`, `text-foreground`, `border-border-input`)
+- Keep variant/size maps as `Record<Variant, string>` with complete literal class strings
+
+## packages/data Conventions
+
+All shared TypeScript types and CMS access live here. See
+[ghost-directus-data.mdc](mdc:.cursor/ghost-directus-data.mdc).
+
+- Never import Svelte or SvelteKit runtime APIs inside `packages/data`
+- All exports are pure TypeScript — no `.svelte` files
+- Every new type file must be exported from `packages/data/src/index.ts`
+
+## Accessibility
+
+This is an accessibility project — a11y is the product, not a checklist item. See
+[accessibility.mdc](mdc:.cursor/accessibility.mdc) for the full rules.
+
+## Anti-Patterns
+
+Never write the following in Svelte 5:
+
+- `$: value = computation` — use `$derived`
+- `export let prop` — use `$props()`
+- `const dispatch = createEventDispatcher()` — use callback props
+- `<slot name="header" />` — use `{#snippet header()}` and `{@render header()}`
+- `<svelte:component this={X} />` — assign to a capitalised local
+- `const store = writable(0)` for local state — use `$state`
+- `on:click={...}` — use `onclick={...}`
+- Fetching data in `onMount` — use `load` functions
+- Mutating a prop directly — use a callback prop or `$bindable`
+- Chaining `$effect` blocks to propagate state — use `$derived`
+
+### Runes Reference (Svelte 5)
+
+| Rune | Replaces | Notes |
+|---|---|---|
+| `$state(val)` | `let x` (top-level reactive) | Deep reactive by default; use `$state.raw` for large lists |
+| `$derived(expr)` | `$: x = expr` | Synchronous, no side effects |
+| `$derived.by(() => {...})` | `$: { x = complex }` | For multi-statement derivations |
+| `$effect(() => {...})` | `$: { sideEffect() }` | Runs after DOM updates; can return cleanup |
+| `$effect.pre(() => {...})` | `beforeUpdate` | Runs before DOM updates |
+| `$props()` | `export let` | Always destructure with types |
+| `$bindable(default)` | `export let x` with `bind:x` | Two-way bindable prop |
+| `$inspect(val)` | `console.log` | Dev-only reactive logger |

--- a/.cursor/tailwind-styling.mdc
+++ b/.cursor/tailwind-styling.mdc
@@ -1,0 +1,248 @@
+---
+description: Tailwind CSS v4 best practices for the a11y.cool monorepo
+globs:
+    - 'packages/ui/**/*.{svelte,ts,css}'
+    - 'apps/blog/**/*.{svelte,css}'
+alwaysApply: true
+docs:
+    - name: Tailwind CSS v4 Documentation
+      url: https://tailwindcss.com/docs
+    - name: Tailwind v4 Theme Variables
+      url: https://tailwindcss.com/docs/theme
+    - name: Tailwind v4 Functions & Directives
+      url: https://tailwindcss.com/docs/functions-and-directives
+---
+
+# Tailwind CSS v4 Styling Practices
+
+This project uses **Tailwind CSS v4** — CSS-first configuration, no `tailwind.config.js`.
+
+> **Never use UnoCSS.** Never add a `tailwind.config.js`/`.ts` — v4 configures through CSS.
+
+## Integration: Vite Plugin
+
+`apps/blog/vite.config.ts` registers `@tailwindcss/vite`:
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+	plugins: [sveltekit(), tailwindcss(), devtoolsJson()]
+});
+```
+
+### App entry CSS
+
+```css
+/* apps/blog/src/global.css */
+@import 'tailwindcss';
+@import '@a11y.cool/ui/globals.css';
+
+@source '../node_modules/@a11y.cool/ui';
+```
+
+The `@source` directive is **required** — without it Tailwind will not scan `@a11y.cool/ui`
+components and their classes will be missing from the build. Add a new `@source` line whenever
+another workspace package starts emitting classes.
+
+## CSS Files: Always go in `packages/ui/src/styles/`
+
+All shared/global CSS rules, custom properties, resets, and base styles **must** live in
+`packages/ui/src/styles/`. Never add global CSS to app-level files unless it is truly app-specific.
+
+```
+packages/ui/src/styles/
+├── globals.css       ← CSS custom properties, @theme inline, resets, base rules
+├── fonts.css         ← @font-face declarations (Geist, Geist Mono, Clash Grotesk)
+├── typography.css    ← prose / typography base styles
+└── code-themes/      ← a11y-dark.css, a11y-light.css for highlight.js output
+```
+
+## Design Tokens
+
+Tokens are defined twice, on purpose:
+
+1. **Raw values** as CSS custom properties on `:root` (and the dark-mode override) in `globals.css`
+2. **Tailwind utilities** generated from them via `@theme inline`
+
+```css
+:root {
+	--background: hsl(0 0% 99%);
+	--foreground: hsl(0 0% 9%);
+	--border-card: hsla(0 0% 10% / 0.1);
+}
+
+@theme inline {
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-border: var(--border-card);
+
+	--radius-card: 16px;
+	--radius-button: 5px;
+	--shadow-card: var(--shadow-card);
+}
+```
+
+`@theme inline` (not plain `@theme`) is what lets the generated utilities follow the runtime value of
+the custom property — required for dark mode to work without regenerating classes.
+
+### Adding a token
+
+1. Add the raw value to `:root` in `globals.css` (and to the dark override if it differs)
+2. Map it under `@theme inline` with the correct namespace prefix:
+   `--color-*`, `--radius-*`, `--shadow-*`, `--text-*`, `--font-*`, `--spacing-*`
+3. Use the generated utility (`bg-<name>`, `rounded-<name>`, `shadow-<name>`)
+
+Never use raw hex values or Tailwind's default palette in components — always use the project tokens.
+
+```svelte
+<!-- ✅ Good -->
+<div class="bg-background text-foreground border border-border-input rounded-card shadow-card" />
+
+<!-- ❌ Bad -->
+<div class="bg-[#fcfcfc] text-zinc-900 border-gray-200" />
+```
+
+> **Before using a token, confirm it exists in `@theme inline`.** An unmapped name is not an error —
+> Tailwind simply emits nothing, so the class silently does nothing. There is no `primary`,
+> `secondary`, `ring`, `input`, `card`, or `popover` in this system; the shadcn-style names do not
+> apply here. Use `dark`/`line`, `muted`, `accent`, `border-input`, `destructive` instead, or add and
+> map a new token.
+
+## Class Organization
+
+Organize utility classes in logical groups:
+
+1. Layout/positioning (`flex`, `grid`, `relative`, `z-10`)
+2. Sizing (`w-full`, `h-10`, `max-w-sm`)
+3. Spacing (`p-6`, `gap-4`, `mt-2`)
+4. Visual styles (`bg-background`, `border`, `rounded-card`)
+5. Typography (`text-sm`, `font-medium`, `text-foreground`)
+6. Interactive states (`hover:bg-muted`, `focus-visible:ring-2`)
+7. Responsive variants last (`md:flex-row`, `lg:hidden`)
+
+## Responsive Design
+
+- Mobile-first: base classes for mobile, prefixed for larger screens
+- Use responsive prefixes: `sm:`, `md:`, `lg:`, `xl:`, `2xl:`
+
+## Dynamic Classes
+
+Tailwind scans source files for **complete, literal** class strings. Never build a class name by
+concatenation:
+
+```svelte
+<!-- ❌ Bad — never generated -->
+<div class="bg-{color}-500" />
+<div class={`text-${size}`} />
+
+<!-- ✅ Good — full strings in a lookup map -->
+<script lang="ts">
+	const variants: Record<Variant, string> = {
+		default: 'bg-dark text-line',
+		outline: 'border border-border-input hover:bg-muted'
+	};
+</script>
+<div class={variants[variant]} />
+```
+
+This project has no `cn()` helper. Merge classes with a `$derived` template string and always put the
+incoming `className` **last** so callers can override:
+
+```svelte
+<script lang="ts">
+	let { variant = 'default', class: className = '' } = $props();
+
+	const buttonClass = $derived(
+		`inline-flex items-center rounded-button ${variants[variant]} ${className}`
+	);
+</script>
+
+<button class={buttonClass}>…</button>
+```
+
+## Color Usage & Dark Mode
+
+Dark mode is **token-driven**, not variant-driven. `globals.css` re-declares every custom property
+inside `@media (prefers-color-scheme: dark)`, so a component written with tokens themes itself:
+
+```svelte
+<!-- ✅ Good — adapts automatically, no dark: variant needed -->
+<div class="bg-background text-foreground border-border-input" />
+
+<!-- ❌ Bad — hardcodes both themes, and duplicates what the token already does -->
+<div class="bg-white dark:bg-black text-black dark:text-white" />
+```
+
+Reach for a `dark:` variant only when the two themes need genuinely different *layout* or *opacity*,
+not different colors. There is no `.dark` class toggle — `dark:` resolves via `prefers-color-scheme`.
+
+- Apply opacity with slash notation: `bg-dark/40`
+- `--line` and `--contrast` invert between themes; use them for elements that must stay opposite the background
+
+## Layout Patterns
+
+- Use `flex` and `grid` for layouts
+- Use `gap` utilities instead of margins between flex/grid children
+- Use the defined radius tokens: `rounded-card`, `rounded-card-sm`, `rounded-input`, `rounded-button`
+
+## Animations
+
+`tailwindcss-animate` is **not** installed — there is no `animate-in` / `animate-out` /
+`fade-in-0` / `zoom-in-95`. Do not write those classes; they produce nothing.
+
+Instead, `globals.css` defines named animations under `@theme inline` with their `@keyframes`
+co-located. Tailwind generates an `animate-<name>` utility for each:
+
+| Utility | Use for |
+|---|---|
+| `animate-fade-in` / `animate-fade-out` | overlays, tooltips |
+| `animate-scale-in` / `animate-scale-out` | dialogs, popovers |
+| `animate-accordion-down` / `animate-accordion-up` | Bits UI Accordion + Collapsible (uses `--bits-accordion-content-height`) |
+| `animate-enter-from-left` / `-right`, `animate-exit-to-left` / `-right` | tabs, navigation menus |
+| `animate-fly-in-up`, `animate-fly-in-up-fast` | on-scroll content reveals |
+| `animate-caret-blink` | text-input carets |
+
+Add a new animation by declaring `--animate-<name>` **and** its `@keyframes` inside the same
+`@theme inline` block — a keyframe outside that block will not be picked up.
+
+## Bits UI + Tailwind
+
+Bits UI sets `data-state="open"` / `data-state="closed"` on animated elements. Combine those data
+attribute variants with the project's `animate-*` utilities:
+
+```svelte
+<Dialog.Content
+	class="data-[state=open]:animate-scale-in data-[state=closed]:animate-scale-out"
+/>
+
+<Accordion.Content
+	class="overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up"
+/>
+```
+
+Always define **both** the open and closed variant — the exit animation will not run otherwise.
+See [bitsui-components.mdc](mdc:.cursor/bitsui-components.mdc).
+
+## Accessibility
+
+Respect `prefers-reduced-motion` for anything decorative — this is an accessibility project; motion
+rules are not optional. `globals.css` already has a global `@media (prefers-reduced-motion: reduce)`
+block, and the `animate` action from `@a11y.cool/utils` bails out entirely when reduce is set.
+
+For scroll-reveal animations, use the action rather than a bare `animate-*` class — it handles the
+IntersectionObserver, the pre-animation hidden state, and reduced motion for you:
+
+```svelte
+<script lang="ts">
+	import { animate, getAnimateInitialClass } from '@a11y.cool/utils';
+</script>
+
+<section use:animate={{ animationClass: 'fly-in-up', delay: 100 }} class={getAnimateInitialClass('fly-in-up')}>
+	…
+</section>
+```
+
+`getAnimateInitialClass()` must be on the same node so the hidden state is present in the SSR HTML
+before hydration. See [accessibility.mdc](mdc:.cursor/accessibility.mdc).

--- a/.cursor/typescript-style.mdc
+++ b/.cursor/typescript-style.mdc
@@ -1,0 +1,204 @@
+---
+description: TypeScript code style conventions for the a11y.cool monorepo
+globs:
+    - '**/*.ts'
+    - '**/*.svelte'
+alwaysApply: false
+docs:
+    - name: TypeScript Handbook
+      url: https://www.typescriptlang.org/docs/handbook/
+    - name: TypeScript tsconfig Reference
+      url: https://www.typescriptlang.org/tsconfig/
+---
+
+# TypeScript Code Style Guide
+
+This rule defines the TypeScript code style conventions for the a11y.cool monorepo. Follow these
+rules for all TypeScript and Svelte files.
+
+## Parameter Passing
+
+Pass parameters as a single object (named parameters pattern) once a function takes more than one
+argument, or when the arguments are the same primitive type:
+
+```ts
+// ✅ Good
+function processUser({ id, name }: { id: string; name: string }) {
+	return { id, displayName: name };
+}
+
+// ✅ Fine — single, unambiguous argument
+export const getPost = async (slug: string): Promise<Post | null> => { … };
+
+// ❌ Bad — positional same-typed args are easy to swap
+function processUser(id: string, name: string) { … }
+```
+
+## Type Safety
+
+- **Never use `any`.** This includes `as any` assertions and generic `T = any` defaults.
+- Use explicit types, interfaces, or `unknown` with type guards.
+- When mapping an untyped third-party payload, take `unknown` and narrow it — the Ghost mappers in
+  `packages/data/src/ghost/ghost.api.ts` are the reference:
+
+    ```ts
+    function mapTag(tag: unknown): Tag {
+    	const t = tag as Record<string, unknown>;
+    	return {
+    		id: (t.id as string) || '',
+    		name: (t.name as string) || ''
+    	};
+    }
+    ```
+
+- **Use union types, not enums.** Enums generate runtime code; prefer `type Status = 'active' | 'inactive'`.
+- Prefer `interface` for object shapes that may be extended; `type` for aliases and unions.
+- Use `satisfies` to validate a literal against a type without widening it — the repo uses this for
+  `MetaTagsProps` and `PageServerLoad`.
+
+## Imports & Path Aliases
+
+Use the project's defined aliases — **never** deep relative paths across package boundaries.
+
+| Alias | Resolves to |
+|---|---|
+| `$lib/*` | `apps/blog/src/lib/*` |
+| `$env/dynamic/public` | SvelteKit public runtime env (app only) |
+| `@a11y.cool/data` | `packages/data` — shared types, Ghost + Directus clients |
+| `@a11y.cool/ui` | `packages/ui` — Svelte component library |
+| `@a11y.cool/utils` | `packages/utils` — pure functions (no shared types) |
+
+```ts
+// ✅ Good
+import type { Post } from '@a11y.cool/data';
+import { getPost } from '@a11y.cool/data';
+import { PostInfo, HtmlRender } from '@a11y.cool/ui';
+import { formatDate, processHtml } from '@a11y.cool/utils';
+import { isBlogEnabled } from '$lib/features';
+
+// ❌ Bad — relative path crossing a package boundary
+import type { Post } from '../../../packages/data/src/types/post.type';
+```
+
+### Shared types (`@a11y.cool/data`)
+
+- **All** types used across apps or packages live in `packages/data/src/types/` (one concern per
+  `*.type.ts` file: `post.type.ts`, `page.type.ts`, `home.type.ts`, `about.type.ts`).
+- Export from `packages/data/src/index.ts` so consumers import `@a11y.cool/data` (deep imports via
+  `@a11y.cool/data/types/…` also work and are used inside the package itself).
+- `@a11y.cool/ui` may **re-export** types for convenience; it must not **define** shared interfaces.
+- `@a11y.cool/utils` is for pure functions only — the types it exports (`AnimationOptions`,
+  `AnimationType`) describe its own API surface, not shared domain shapes.
+
+## Named Exports
+
+Use named exports everywhere. The only default exports are `.svelte` component files, which the
+`packages/ui` barrel converts to named exports:
+
+```ts
+// ✅ Good
+export const getPosts = async (): Promise<Post[]> => { … };
+export type { Post };
+export { default as Button } from './src/components/Button.svelte';
+
+// ❌ Bad
+export default function getPosts() { … }
+```
+
+## Classes
+
+Classes are **only** appropriate for Svelte 5 shareable rune patterns. For pure logic, prefer plain
+functions or a factory that returns an object — as `createAnimation()` does in
+`packages/utils/src/animation.ts`.
+
+```ts
+// ❌ Bad — class for logic that should be a function
+class DateFormatter {
+	format(date: Date) {
+		return date.toISOString();
+	}
+}
+```
+
+## Control Flow
+
+- **Always wrap `if` bodies in curly braces**, even for single-line blocks.
+- Use early returns and guard clauses; avoid deeply nested conditionals.
+
+```ts
+// ✅ Good
+if (!isGhostConfigured()) {
+	return [];
+}
+return fetchPosts();
+
+// ❌ Bad
+if (isActive) doSomething();
+else doOtherThing();
+```
+
+## Error Handling
+
+Data-fetching functions in `packages/data` **degrade, they do not throw**. When a CMS is
+unconfigured or unreachable they log a warning and return an empty/null result so the site still
+renders. Preserve that contract when adding a fetcher:
+
+```ts
+export const getThing = async (): Promise<Thing | null> => {
+	if (!apiUrl || !apiToken) {
+		console.warn('Directus API is not configured; skipping data fetch.');
+		return null;
+	}
+
+	try {
+		// …
+	} catch (err) {
+		console.warn('Failed to fetch thing:', err);
+		return null;
+	}
+};
+```
+
+Route-level `load` functions decide what a missing result means — `error(404, …)` for a missing post,
+a rendered empty state for missing page content.
+
+## Comments and Documentation
+
+- **Do not comment obvious things.** Never narrate what the code does.
+- **Only document non-obvious intent**, trade-offs, or constraints.
+- Use JSDoc for exported functions intended for consumers of a package.
+
+```ts
+// ✅ Good — explains a non-obvious constraint
+/** CSS class that hides the element before its enter animation (use on the same node as `use:animate`). */
+export const getAnimateInitialClass = (animationClass = 'fly-in-up'): string => …;
+
+// ❌ Bad — narrates what the code does
+// Increment the counter
+count++;
+```
+
+## Utility Functions
+
+- Place shared helpers in `packages/utils/src/` and export them from `packages/utils/index.ts`.
+- Place app-specific helpers in `apps/blog/src/lib/`.
+
+## Environment Variables
+
+| Where | How to read | Example |
+|---|---|---|
+| `packages/data` (server-only) | `process.env` + `dotenv` | `VITE_GHOST_API_URL`, `VITE_API_TOKEN` |
+| `apps/blog` (public, runtime) | `$env/dynamic/public` | `PUBLIC_BLOG_ENABLED` |
+
+Never read a token in code that can reach the browser. Always guard on the variable being present
+and degrade gracefully rather than throwing at import time.
+
+## Strict TypeScript Config
+
+All packages extend `@a11y.cool/typescript-config/svelte.json`. Key settings active:
+
+- `strict: true`
+- `moduleResolution: "bundler"`
+- `isolatedModules: true` — use `import type` for type-only imports
+- `checkJs: true` — `.js` config files are type-checked too
+- `noEmit: true`

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ coverage
 .DS_Store
 *.pem
 
+# agent tooling — shared config is committed, machine-local overrides are not
+.claude/settings.local.json
+.claude/.DS_Store
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 # agent tooling — shared config is committed, machine-local overrides are not
 .claude/settings.local.json
 .claude/.DS_Store
+.conductor/settings.local.toml
 
 # debug
 npm-debug.log*

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"pluginSearchDirs": ["."],
+	"plugins": ["prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# a11y.cool
+
+Claude context entrypoint: **@.cursor/claude-context.md**

--- a/apps/blog/src/routes/blog/[slug]/+page.svelte
+++ b/apps/blog/src/routes/blog/[slug]/+page.svelte
@@ -7,48 +7,37 @@
 
 	let { data } = $props<{ data: PageData }>();
 
-	// Make post reactive to data
-	let post = $derived(() => data?.post);
-
-	// Make ast reactive to post?.content
-	let ast = $derived(() => processHtml(post()?.content));
-
-	// Derive the title ID
-	let titleId = $derived(() => (post()?.title ? slugify(post().title) : ''));
+	let post = $derived(data?.post);
+	let ast = $derived(processHtml(post?.content));
+	let titleId = $derived(post?.title ? slugify(post.title) : '');
 </script>
 
-{#if post()}
+{#if post}
 	<section
 		class="col-span-12 col-start-1 flex justify-center {animateInitial}"
 		use:animate={{ delay: 100, triggerOnMount: true }}
 	>
 		<article class="pt-10 max-w-[580px] w-full">
 			<header class="mb-8 {animateInitial}" use:animate={{ delay: 150, triggerOnMount: true }}>
-				<a
-					href="#{titleId()}"
-					class="no-underline hover:underline focus:underline focus-visible:outline-none"
-				>
-					<h1 id={titleId()} class="text-4xl font-bold mb-4">{post().title}</h1>
+				<a href="#{titleId}" class="no-underline hover:underline focus:underline">
+					<h1 id={titleId} class="text-4xl font-bold mb-4">{post.title}</h1>
 				</a>
 				<PostInfo
-					authors={post().authors}
-					publishedAt={post().publishedAt}
-					readingTime={post().readingTime}
+					authors={post.authors}
+					publishedAt={post.publishedAt}
+					readingTime={post.readingTime}
 				/>
 			</header>
 
-			{#if post().coverImage}
+			{#if post.coverImage}
 				<div class={animateInitial} use:animate={{ delay: 200, triggerOnMount: true }}>
-					<img src={post().coverImage} alt={post().title} class="w-full h-auto rounded-lg mb-8" />
+					<img src={post.coverImage} alt="" class="w-full h-auto rounded-lg mb-8" />
 				</div>
 			{/if}
 
-			<div
-				class="prose prose-lg max-w-none {animateInitial}"
-				use:animate={{ delay: 250, triggerOnMount: true }}
-			>
-				{#if ast()}
-					<HtmlRender node={ast()!} />
+			<div class="max-w-none {animateInitial}" use:animate={{ delay: 250, triggerOnMount: true }}>
+				{#if ast}
+					<HtmlRender node={ast} />
 				{/if}
 			</div>
 		</article>

--- a/packages/ui/src/components/Button.svelte
+++ b/packages/ui/src/components/Button.svelte
@@ -4,7 +4,9 @@
 	type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
 	type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
 	type ButtonType = 'button' | 'submit' | 'reset';
-	type IconSnippet = Snippet<[{ class?: string; 'aria-hidden'?: string }]>;
+	// `aria-hidden` is narrowed to the literals rather than `string` so the props object stays
+	// assignable to icon libraries (e.g. phosphor-svelte) that type it as Booleanish.
+	type IconSnippet = Snippet<[{ class?: string; 'aria-hidden'?: 'true' | 'false' }]>;
 
 	let {
 		variant = 'default' as ButtonVariant,
@@ -18,17 +20,17 @@
 		...props
 	} = $props();
 
+	// Only tokens mapped in @theme inline (packages/ui/src/styles/globals.css) may be used here.
+	// `primary`/`secondary`/`ring`/`input` are NOT mapped — classes referencing them render nothing.
+	// Focus styling is intentionally absent: globals.css applies a focus-visible ring to every
+	// element, so re-declaring it here would be redundant.
 	const variants: Record<ButtonVariant, string> = {
-		default:
-			'bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-		destructive:
-			'bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2',
-		outline:
-			'border border-input hover:bg-muted hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-		secondary:
-			'bg-secondary text-secondary-foreground hover:bg-secondary/80 focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2',
-		ghost: 'hover:bg-muted hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-		link: 'text-primary underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
+		default: 'bg-dark text-line hover:bg-dark/90',
+		destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+		outline: 'border border-border-input hover:bg-muted hover:text-accent-foreground',
+		secondary: 'bg-muted text-foreground hover:bg-muted/80',
+		ghost: 'hover:bg-muted hover:text-accent-foreground',
+		link: 'text-foreground underline-offset-4 hover:underline'
 	};
 
 	const sizes: Record<ButtonSize, string> = {
@@ -39,7 +41,7 @@
 	};
 
 	const buttonClass = $derived(
-		`inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`
+		`inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`
 	);
 </script>
 

--- a/packages/ui/src/components/CodeRender.svelte
+++ b/packages/ui/src/components/CodeRender.svelte
@@ -74,14 +74,11 @@
 			</span>
 		{/if}
 		{#if copyButton}
-			<Button
-				variant="ghost"
-				size="sm"
-				onclick={handleCopy}
-				icon={copied ? Check : CopySimple}
-				iconSize={16}
-				iconPosition="start"
-			>
+			<Button variant="ghost" size="sm" onclick={handleCopy}>
+				{#snippet leftIcon(iconProps)}
+					{@const Icon = copied ? Check : CopySimple}
+					<Icon size={16} {...iconProps} />
+				{/snippet}
 				{copied ? 'Code copied' : 'Copy code'}
 			</Button>
 		{/if}

--- a/packages/ui/src/components/Footer.svelte
+++ b/packages/ui/src/components/Footer.svelte
@@ -11,10 +11,7 @@
 	const animateInitial = getAnimateInitialClass();
 </script>
 
-<div
-	class="col-span-12 {animateInitial}"
-	use:animate={{ delay: entryDelay, triggerOnMount: true }}
->
+<div class="col-span-12 {animateInitial}" use:animate={{ delay: entryDelay, triggerOnMount: true }}>
 	<hr class="mt-20 md:mt-32 lg:mt-40 border-t border-border-input sm:mb-6 mb-1 w-full" />
 
 	<footer class="grid grid-cols-12 gap-4 md:gap-3 sm:gap-2 xs:gap-1 py-6">

--- a/packages/ui/src/components/Header.svelte
+++ b/packages/ui/src/components/Header.svelte
@@ -12,10 +12,7 @@
 		navItems?: NavItem[];
 	};
 
-	let {
-		entryDelay = 0,
-		navItems = [{ label: 'About Us', href: '/about' }]
-	}: Props = $props();
+	let { entryDelay = 0, navItems = [{ label: 'About Us', href: '/about' }] }: Props = $props();
 
 	const animateInitial = getAnimateInitialClass();
 </script>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -23,6 +23,9 @@
 	--accent: hsl(0, 0%, 55%);
 	--accent-foreground: hsl(0, 0%, 19%);
 	--destructive: hsl(347 77% 50%);
+	/* Near-white reads 4.8:1 on the light-mode destructive red (AA). The dark-mode
+	   red is lighter, so that theme flips this to near-black — see the dark block. */
+	--destructive-foreground: hsl(0 0% 98%);
 	--tertiary: hsl(37.7 92.1% 50.2%);
 	--line: hsl(0 0% 100%);
 	--contrast: hsl(0 0% 0%);
@@ -59,6 +62,7 @@
 		--accent: hsl(0, 0%, 51%);
 		--accent-foreground: hsl(0, 0%, 94%);
 		--destructive: hsl(350 89% 60%);
+		--destructive-foreground: hsl(0 0% 9%);
 		--line: hsl(0 0% 9.02%);
 		--tertiary: hsl(61.3 100% 82.2%);
 		--contrast: hsl(0 0% 100%);
@@ -93,6 +97,7 @@
 	--color-accent: var(--accent);
 	--color-accent-foreground: var(--accent-foreground);
 	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
 	--color-tertiary: var(--tertiary);
 	--color-line: var(--line);
 	--color-contrast: var(--contrast);

--- a/packages/utils/src/animation.ts
+++ b/packages/utils/src/animation.ts
@@ -87,8 +87,7 @@ const scheduleAnimation = (
 };
 
 const prefersReducedMotion = (): boolean =>
-	typeof window !== 'undefined' &&
-	window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 export const createAnimation = (options: AnimationOptions = {}) => {
 	const {
@@ -248,8 +247,7 @@ export const animate = (node: HTMLElement, options: AnimationOptions = {}) => {
 	return {
 		update: (newOptions: AnimationOptions) => {
 			const newAnimationClass = newOptions.animationClass || animationClass;
-			const newCssClass =
-				ANIMATION_CLASSES[newAnimationClass as AnimationType] || cssClass;
+			const newCssClass = ANIMATION_CLASSES[newAnimationClass as AnimationType] || cssClass;
 			const newInitialClass = getInitialClass(newAnimationClass);
 
 			if (newCssClass !== cssClass && hasAnimated) {

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -5,7 +5,11 @@
 
 set -e  # Exit on any error
 
-echo "🚀 Starting dependency updates across all packages..."
+# Update target: pass "minor" (or "patch") to limit to safe upgrades.
+# Defaults to "latest" (includes major versions) to preserve existing behavior.
+TARGET="${1:-latest}"
+
+echo "🚀 Starting dependency updates across all packages (target: $TARGET)..."
 
 # Function to update dependencies in a directory
 update_package() {
@@ -16,11 +20,11 @@ update_package() {
         
         # Update regular dependencies
         echo "  → Updating regular dependencies..."
-        ncu --upgrade --target latest --dep prod
+        ncu --upgrade --target "$TARGET" --dep prod
         
         # Update dev dependencies
         echo "  → Updating dev dependencies..."
-        ncu --upgrade --target latest --dep dev
+        ncu --upgrade --target "$TARGET" --dep dev
         
         cd - > /dev/null
         echo "✅ Updated $dir"
@@ -36,8 +40,8 @@ cd "$SCRIPT_DIR"
 
 # Update root package.json
 echo "📦 Updating root package.json..."
-ncu --upgrade --target latest --dep prod
-ncu --upgrade --target latest --dep dev
+ncu --upgrade --target "$TARGET" --dep prod
+ncu --upgrade --target "$TARGET" --dep dev
 
 # Update all apps
 echo "📱 Updating apps..."


### PR DESCRIPTION
Ports the agent configuration from `28mm-web` and fixes a cluster of silent bugs found while auditing this codebase to write the rules accurately.

Two commits, reviewable independently:

1. `chore:` — agent config only, no runtime code touched
2. `fix:` — the bugs

## 1. Agent config

28mm's rules are written for **UnoCSS + Sanity + Vercel**, and several explicitly say *"Never use Tailwind CSS"* — which this repo uses exclusively. So this is a rewrite against our actual stack, not a copy.

| | 28mm-web | a11y.cool |
|---|---|---|
| Styling | UnoCSS | **Tailwind v4** (`@theme inline`) |
| CMS | Sanity + GROQ | **Ghost + Directus** |
| Apps | website, catalog, cms | blog only |
| UI layout | folder-per-component + `cn()` | flat `src/components/` + root barrel |
| Deploy | Vercel | Netlify |

- `.cursor/` — `monorepo`, `svelte`, `typescript-style`, `bitsui-components`, `cursor-rules`, `self-improve`, `git-policy`, plus `tailwind-styling` (replaces `unocss-styling`), `ghost-directus-data` (replaces `sanity-cms`), and a new `accessibility` rule encoding the global focus ring and reduced-motion handling this repo already implements.
- `.claude/` — `settings.json`, the `update-deps` skill, and commands `debug`, `typecheck`, `new-route`, `new-component`, `new-package`, `build-bits-component`, `new-data-type` (replaces `new-sanity-type`).
- `update-deps.sh` gains a `TARGET` arg (`./update-deps.sh minor`); default stays `latest`.

28mm's `PostToolUse` hook is **deliberately not ported** — it reads `$CLAUDE_TOOL_INPUT_PATH` (not a variable Claude Code sets) and uses `grep -oP` (unavailable in macOS BSD grep). It has never fired in 28mm either.

## 2. The bugs

Every one was silent — no error, no warning, just no effect.

**Unmapped design tokens.** Every `Button` variant referenced `bg-primary`, `bg-secondary`, `ring-ring`, or `border-input`. None are mapped in `@theme inline`, so Tailwind emitted nothing. I remapped the variants onto tokens that exist rather than inventing a brand color scale — that's a design decision, not mine to make. Only `ghost` is used anywhere (in `CodeRender`) and it was already valid, **so no visual change ships**; the other five now work instead of rendering nothing.

**`--destructive-foreground` added** — referenced but never defined. Near-white in light (4.8:1 on the red), flipped to near-black in dark, where the lighter red would leave white at ~3.3:1 and fail AA. :eyes: **This contrast pair is the one judgment call worth a designer's review.**

**The copy-code icon has never rendered.** `CodeRender` passed `icon`/`iconSize`/`iconPosition`, but `Button` declares `leftIcon`/`rightIcon` snippets — the props fell through `...props` onto the DOM as invalid attributes. Fixed via the snippet API, which surfaced a genuine type flaw in `IconSnippet` (`aria-hidden` typed as `string`, not satisfying phosphor's `Booleanish`).

**Dead `prose` classes.** `@tailwindcss/typography` isn't installed and there's no `@plugin` directive, so `prose prose-lg` emitted no CSS — confirmed by grepping the built stylesheet. Post content is styled by the bare-element rules in `typography.css`, so removing them is a no-op.

**`$derived` thunks.** `$derived(() => data?.post)` returns a new function identity on every read and defeats fine-grained tracking. Now `$derived(data?.post)`.

**Prettier never loaded the Svelte plugin.** `pluginSearchDirs` was removed in Prettier 3, so `prettier --check .` aborted on `.svelte` files. Switched to `plugins`. This exposed three files skipped ever since the Prettier 3 upgrade — `Footer.svelte`, `Header.svelte`, `animation.ts` — now formatted.

**Accessibility:** the cover image used the post title as `alt`, duplicating the adjacent `<h1>` for screen readers → `alt=""`. Dropped a redundant `focus-visible:outline-none` on the title link.

## Verification

`pnpm lint`, `svelte-check` (0 errors / 0 warnings), `pnpm check-types`, and `pnpm build` all pass. `prettier --check .` is clean for the first time.

Confirmed against the built CSS that `.text-destructive-foreground`, `.bg-dark`, and `.text-line` now emit, while `bg-primary`, `ring-ring`, and `prose` emit nothing — i.e. the removed classes really were dead.

**Not verified end-to-end:** the blog route needs Ghost credentials plus `PUBLIC_BLOG_ENABLED=true`, so the post page was confirmed to compile and generate CSS, but never rendered against live content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)