### PR TITLE
Add Conductor repository settings with setup and run scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,27 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "pnpm install --frozen-lockfile"
+run_mode = "concurrent"
+
+# SvelteKit dev server. Each workspace gets its own port range, so several
+# workspaces can run side by side. --strictPort makes a port clash fail loudly
+# instead of silently drifting into a neighbouring workspace's range.
+[scripts.run.dev]
+command = "pnpm --filter a11y.cool-website dev --port $CONDUCTOR_PORT --strictPort"
+default = true
+icon = "play"
+
+# Production build served locally (Netlify parity). Uses PORT+1 so it can run
+# alongside the dev server in the same workspace.
+[scripts.run.preview]
+command = "pnpm build && pnpm --filter a11y.cool-website preview --port $((CONDUCTOR_PORT + 1)) --strictPort"
+icon = "globe"
+
+[scripts.run.test]
+command = "pnpm --filter a11y.cool-website test:unit"
+icon = "test-tube"
+
+[scripts.run.check]
+command = "pnpm lint && pnpm check-types"
+icon = "wrench"


### PR DESCRIPTION
Conductor had no setup or run script configured for this repo, so new workspaces started without `node_modules` and the Run button had no command. This adds `.conductor/settings.toml` with a `pnpm install --frozen-lockfile` setup step and four run scripts: `dev` (default), `preview`, `test`, and `check`. The dev and preview servers bind to `$CONDUCTOR_PORT` (and `+1`) with `--strictPort`, so `run_mode` is `concurrent` and multiple workspaces can run side by side without colliding.

Each script was verified by running it in a non-interactive zsh: setup installed 361 packages, dev and preview both served HTTP 200 on their injected ports, vitest passed, and lint + `tsc --noEmit` were clean. Playwright is deliberately excluded from the `test` script because `playwright.config.ts` hardcodes port 4173, which would collide across concurrent workspaces — note it currently fails with "No tests found" on `dev` regardless, since `apps/blog/tests/` doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)